### PR TITLE
docs: note SchemaHistoryExporter for schema history CI parity.

### DIFF
--- a/src/Migrations/README.md
+++ b/src/Migrations/README.md
@@ -48,6 +48,8 @@ Ensure the **database** (e.g. `Chess`) already exists; DbUp does not create it. 
 
 `src/Migrations/History/current/` contains a generated snapshot of current SQL object definitions (tables, views, procedures, functions, and user-defined table types).
 
+**CI:** the “Schema history” GitHub workflow uses `SchemaHistoryExporter`; when you refresh `History/current` for a PR, regenerate with that project too so output matches CI.
+
 Generate/update it from repo root:
 
 ```powershell


### PR DESCRIPTION
## Summary

Documents that GitHub’s “Schema history” workflow uses `SchemaHistoryExporter`, so developers should refresh `src/Migrations/History/current` with the same tool to avoid CI drift.

## Changes

- Add a short **CI** note under **Schema history snapshot** in `src/Migrations/README.md`.

## How to test

- No code changes; skim `src/Migrations/README.md` for clarity and accuracy.

## Notes

- PowerShell `tools/export-db-history.ps1` remains documented for local use; the new note clarifies parity with the CI exporter when updating history for PRs.