### PR TITLE
feat(api): add optional filters to paged GetGames.

### DIFF
--- a/src/Analyser/Controllers/AnalyserController.cs
+++ b/src/Analyser/Controllers/AnalyserController.cs
@@ -101,23 +101,51 @@ public class AnalyserController(
 
     /// <summary>
     /// Get one page of games from the database (ordered by Id). Defaults: page 1, page 50; pageSize is capped at 500.
+    /// Optional filters combine with AND. Games with null <c>GameYear</c> are excluded when a year bound is set.
     /// </summary>
     /// <param name="page">1-based page number.</param>
     /// <param name="pageSize">Rows per page (1–500).</param>
+    /// <param name="minGameYear">Lower bound on <c>GameYear</c> (inclusive).</param>
+    /// <param name="maxGameYear">Upper bound on <c>GameYear</c> (inclusive).</param>
+    /// <param name="whitePlayerId">Exact match on <c>WhitePlayerId</c>.</param>
+    /// <param name="blackPlayerId">Exact match on <c>BlackPlayerId</c>.</param>
+    /// <param name="eco">Exact match on persisted <c>Eco</c> (trimmed, max 16 characters).</param>
     /// <param name="cancellationToken">Propagates cancellation from the client.</param>
     [HttpGet("GetGames")]
     [Produces("application/json")]
     public async Task<IActionResult> GetGames(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
+        [FromQuery] short? minGameYear = null,
+        [FromQuery] short? maxGameYear = null,
+        [FromQuery] int? whitePlayerId = null,
+        [FromQuery] int? blackPlayerId = null,
+        [FromQuery] string? eco = null,
         CancellationToken cancellationToken = default)
     {
         if (page < 1)
             return BadRequest("page must be >= 1.");
         if (pageSize < 1 || pageSize > 500)
             return BadRequest("pageSize must be between 1 and 500.");
+        if (minGameYear.HasValue && maxGameYear.HasValue && minGameYear.Value > maxGameYear.Value)
+            return BadRequest("minGameYear must be <= maxGameYear when both are set.");
 
-        var pageResult = await _chessRepository.GetGamesPage(page, pageSize, cancellationToken).ConfigureAwait(false);
+        var ecoTrimmed = string.IsNullOrWhiteSpace(eco) ? null : eco.Trim();
+        if (ecoTrimmed != null && ecoTrimmed.Length > 16)
+            return BadRequest("eco must be at most 16 characters after trimming.");
+
+        GamePageFilters? filters = minGameYear.HasValue || maxGameYear.HasValue || whitePlayerId.HasValue || blackPlayerId.HasValue || ecoTrimmed != null
+            ? new GamePageFilters
+            {
+                MinGameYear = minGameYear,
+                MaxGameYear = maxGameYear,
+                WhitePlayerId = whitePlayerId,
+                BlackPlayerId = blackPlayerId,
+                Eco = ecoTrimmed
+            }
+            : null;
+
+        var pageResult = await _chessRepository.GetGamesPage(page, pageSize, filters, cancellationToken).ConfigureAwait(false);
         return Ok(pageResult);
     }
 }

--- a/src/Interfaces/DTO/GamePageFilters.cs
+++ b/src/Interfaces/DTO/GamePageFilters.cs
@@ -1,0 +1,18 @@
+namespace Interfaces.DTO;
+
+/// <summary>
+/// Optional filters for paged game listing. When multiple properties are set, they combine with AND.
+/// </summary>
+public sealed class GamePageFilters
+{
+    public short? MinGameYear { get; init; }
+
+    public short? MaxGameYear { get; init; }
+
+    public int? WhitePlayerId { get; init; }
+
+    public int? BlackPlayerId { get; init; }
+
+    /// <summary>Exact match on persisted <c>Eco</c> (max 16 characters in DB).</summary>
+    public string? Eco { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -15,9 +15,14 @@ namespace Repositories
 
         /// <summary>
         /// One page of rows from <c>dbo.Game</c> ordered by <c>Id</c>, plus total row count.
+        /// Optional <paramref name="filters"/> apply with AND semantics (see <see cref="GamePageFilters"/>).
         /// Honors <paramref name="cancellationToken"/> and uses a bounded command timeout.
         /// </summary>
-        Task<PagedResult<Game>> GetGamesPage(int page, int pageSize, CancellationToken cancellationToken = default);
+        Task<PagedResult<Game>> GetGamesPage(
+            int page,
+            int pageSize,
+            GamePageFilters? filters,
+            CancellationToken cancellationToken = default);
 
         Task<List<string>> GetProcessedGameIds();
 
@@ -99,7 +104,11 @@ namespace Repositories
         public IConfiguration Configuration => throw new NotImplementedException();
 
         /// <inheritdoc />
-        public async Task<PagedResult<Game>> GetGamesPage(int page, int pageSize, CancellationToken cancellationToken = default)
+        public async Task<PagedResult<Game>> GetGamesPage(
+            int page,
+            int pageSize,
+            GamePageFilters? filters,
+            CancellationToken cancellationToken = default)
         {
             var connectionString = _config.GetConnectionString("ChessConnection")
                 ?? throw new InvalidOperationException("Connection string 'ChessConnection' is not configured.");
@@ -107,20 +116,46 @@ namespace Repositories
             await using var connection = new SqlConnection(connectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
+            var offset = (page - 1) * pageSize;
+            var eco = NormalizeEco(filters?.Eco);
+            var filterParams = new
+            {
+                MinGameYear = filters?.MinGameYear,
+                MaxGameYear = filters?.MaxGameYear,
+                WhitePlayerId = filters?.WhitePlayerId,
+                BlackPlayerId = filters?.BlackPlayerId,
+                Eco = eco,
+                Offset = offset,
+                PageSize = pageSize
+            };
+
+            const string whereClause =
+                """
+                WHERE (@MinGameYear IS NULL OR [GameYear] >= @MinGameYear)
+                  AND (@MaxGameYear IS NULL OR [GameYear] <= @MaxGameYear)
+                  AND (@WhitePlayerId IS NULL OR [WhitePlayerId] = @WhitePlayerId)
+                  AND (@BlackPlayerId IS NULL OR [BlackPlayerId] = @BlackPlayerId)
+                  AND (@Eco IS NULL OR [Eco] = @Eco)
+                """;
+
+            var countSql = "SELECT COUNT(1) FROM dbo.[Game] " + whereClause;
             var countCmd = new CommandDefinition(
-                "SELECT COUNT(1) FROM dbo.[Game]",
+                countSql,
+                filterParams,
                 commandTimeout: 120,
                 cancellationToken: cancellationToken);
             var totalCount = await connection.ExecuteScalarAsync<int>(countCmd).ConfigureAwait(false);
 
-            var offset = (page - 1) * pageSize;
-            var pageCmd = new CommandDefinition(
+            var pageSql =
                 """
                 SELECT * FROM dbo.[Game]
+                """ + whereClause + """
                 ORDER BY [Id]
                 OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY
-                """,
-                new { Offset = offset, PageSize = pageSize },
+                """;
+            var pageCmd = new CommandDefinition(
+                pageSql,
+                filterParams,
                 commandTimeout: 120,
                 cancellationToken: cancellationToken);
             var rows = (await connection.QueryAsync<Game>(pageCmd).ConfigureAwait(false)).ToList();
@@ -132,6 +167,14 @@ namespace Repositories
                 PageSize = pageSize,
                 TotalCount = totalCount
             };
+        }
+
+        private static string? NormalizeEco(string? eco)
+        {
+            if (string.IsNullOrWhiteSpace(eco))
+                return null;
+            var t = eco.Trim();
+            return t.Length == 0 ? null : t;
         }
 
         /// <summary>

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -14,7 +14,7 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
     public IConfiguration Configuration =>
         throw new InvalidOperationException($"{nameof(MaterializationWriteOnlyNoOpRepository)} does not expose configuration.");
 
-    public Task<PagedResult<Game>> GetGamesPage(int page, int pageSize, CancellationToken cancellationToken = default) =>
+    public Task<PagedResult<Game>> GetGamesPage(int page, int pageSize, GamePageFilters? filters, CancellationToken cancellationToken = default) =>
         Throw<PagedResult<Game>>();
 
     public Task<List<string>> GetProcessedGameIds() => Throw<List<string>>();

--- a/test/AnalyserTests/AnalyserControllerTests.cs
+++ b/test/AnalyserTests/AnalyserControllerTests.cs
@@ -100,7 +100,7 @@ namespace ControllerTests
             };
             var chessRepoMock = new Mock<IChessRepository>();
             chessRepoMock
-                .Setup(r => r.GetGamesPage(1, 50, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetGamesPage(1, 50, null, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(page);
             var etlServiceMock = new Mock<IEtlService>();
             var progressStoreMock = new Mock<IEtlProgressStore>();
@@ -115,12 +115,107 @@ namespace ControllerTests
                 pgnOptions);
             var result = await controller.GetGames();
 
-            chessRepoMock.Verify(r => r.GetGamesPage(1, 50, It.IsAny<CancellationToken>()), Times.Once);
+            chessRepoMock.Verify(r => r.GetGamesPage(1, 50, null, It.IsAny<CancellationToken>()), Times.Once);
             var okResult = Assert.IsType<OkObjectResult>(result);
             var returned = Assert.IsType<PagedResult<Game>>(okResult.Value);
             Assert.Single(returned.Items);
             Assert.Equal("G", returned.Items[0].Name);
             Assert.Equal(1, returned.TotalCount);
+        }
+
+        [Fact]
+        public async Task GetGames_WithFilters_PassesFiltersToRepository()
+        {
+            var page = new PagedResult<Game> { Items = [], Page = 1, PageSize = 10, TotalCount = 0 };
+            var chessRepoMock = new Mock<IChessRepository>();
+            chessRepoMock
+                .Setup(r => r.GetGamesPage(
+                    1,
+                    10,
+                    It.Is<GamePageFilters>(f =>
+                        f != null
+                        && f.MinGameYear == 1990
+                        && f.MaxGameYear == 2000
+                        && f.WhitePlayerId == 3
+                        && f.BlackPlayerId == 7
+                        && f.Eco == "B90"),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(page);
+            var etlServiceMock = new Mock<IEtlService>();
+            var progressStoreMock = new Mock<IEtlProgressStore>();
+            var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var pgnOptions = Options.Create(new Analyser.PgnOptions { DefaultFilePath = "C:\\Library\\PGN" });
+
+            var controller = new Analyser.Controllers.AnalyserController(
+                chessRepoMock.Object,
+                etlServiceMock.Object,
+                progressStoreMock.Object,
+                scopeFactoryMock.Object,
+                pgnOptions);
+
+            await controller.GetGames(1, 10, 1990, 2000, 3, 7, "B90");
+
+            chessRepoMock.Verify(
+                r => r.GetGamesPage(
+                    1,
+                    10,
+                    It.Is<GamePageFilters>(f =>
+                        f != null
+                        && f.MinGameYear == 1990
+                        && f.MaxGameYear == 2000
+                        && f.WhitePlayerId == 3
+                        && f.BlackPlayerId == 7
+                        && f.Eco == "B90"),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetGames_WhenMinYearGreaterThanMaxYear_ReturnsBadRequest()
+        {
+            var chessRepoMock = new Mock<IChessRepository>();
+            var etlServiceMock = new Mock<IEtlService>();
+            var progressStoreMock = new Mock<IEtlProgressStore>();
+            var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var pgnOptions = Options.Create(new Analyser.PgnOptions { DefaultFilePath = "C:\\Library\\PGN" });
+
+            var controller = new Analyser.Controllers.AnalyserController(
+                chessRepoMock.Object,
+                etlServiceMock.Object,
+                progressStoreMock.Object,
+                scopeFactoryMock.Object,
+                pgnOptions);
+
+            var result = await controller.GetGames(1, 50, 2010, 2000);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            chessRepoMock.Verify(
+                r => r.GetGamesPage(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<GamePageFilters?>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task GetGames_WhenEcoTooLong_ReturnsBadRequest()
+        {
+            var chessRepoMock = new Mock<IChessRepository>();
+            var etlServiceMock = new Mock<IEtlService>();
+            var progressStoreMock = new Mock<IEtlProgressStore>();
+            var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var pgnOptions = Options.Create(new Analyser.PgnOptions { DefaultFilePath = "C:\\Library\\PGN" });
+
+            var controller = new Analyser.Controllers.AnalyserController(
+                chessRepoMock.Object,
+                etlServiceMock.Object,
+                progressStoreMock.Object,
+                scopeFactoryMock.Object,
+                pgnOptions);
+
+            var result = await controller.GetGames(1, 50, eco: new string('A', 17));
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            chessRepoMock.Verify(
+                r => r.GetGamesPage(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<GamePageFilters?>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
     }
 }


### PR DESCRIPTION
## Summary

Extends `GET /Analyser/GetGames` with optional query filters so Swagger and other clients can narrow results without loading unrelated pages. Filters align with existing analytics dimensions (year range, player IDs, ECO) and combine with AND semantics.

## Changes

- Added `GamePageFilters` (`minGameYear`, `maxGameYear`, `whitePlayerId`, `blackPlayerId`, `eco`) and extended `IChessRepository.GetGamesPage` with an optional `GamePageFilters?` argument before `CancellationToken`.
- `ChessRepository` applies a single parameterized `WHERE` clause to both the count and paged `SELECT` (same 120s command timeout).
- `AnalyserController` binds query parameters, validates `minGameYear <= maxGameYear` when both are set, rejects `eco` longer than 16 characters after trim, and passes `null` filters when no filter query params are used.
- Updated `MaterializationWriteOnlyNoOpRepository` and added controller tests for happy-path filters, invalid year range, and oversized `eco`.

## How to test

- `dotnet build ChessAnalyser.sln`
- `dotnet test ChessAnalyser.sln`
- Swagger: `GET /Analyser/GetGames` with combinations such as `minGameYear`, `maxGameYear`, `whitePlayerId`, `blackPlayerId`, `eco` (verify 400 for `minGameYear` > `maxGameYear` or `eco` length > 16).

## Notes

**API change:** `GetGamesPage` callers must pass the new `filters` argument (use `null` for no filters). HTTP route and default paging behaviour are unchanged when filter query parameters are omitted.