### PR TITLE
docs: defer metrics HTTP auth for local-only use (PLAN §12.4)

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-05-10 (PLAN §12 Stage 4: metrics HTTP API on `Analyser`; DESIGN F-9 / Q7; `AnalyticsMetricsControllerTests`).
+**Last updated:** 2026-05-10 (PLAN **§12.4**: metrics extension prioritized; HTTP auth **deferred** for local-only use — see [PLAN.md §12.4](./PLAN.md).)
 
 ---
 
@@ -13,7 +13,7 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 | File | Role |
 |------|------|
 | [DESIGN.md](./DESIGN.md) | Requirements and locked decisions (facts, dimensions, C# vs SQL, rollups, year rules). |
-| [PLAN.md](./PLAN.md) | Implementation plan; **§11** (closed) + **§12** (metrics HTTP API). |
+| [PLAN.md](./PLAN.md) | Implementation plan; **§11** (closed) + **§12** (metrics HTTP API) + **§12.4** (current suggested slice). |
 | **AGENT_CONTEXT.md** (this file) | Current progress and **recommended next small step**. |
 
 **Global process skill:** `~/.cursor/skills/dpi-workflow/` (`dpi-workflow`) — 80/20 DESIGN+PLAN vs IMPLEMENT; applies in any repo.
@@ -24,15 +24,15 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 - **Done:** PGN parse → player resolution → bitboard positions per ply → persist **`Game`**, **`BoardPosition`**, **`Player`**, parse errors. GitHub Actions runs **`dotnet test`** on PRs.
 - **Housekeeping added:** schema-history scaffolding (`src/Migrations/History/` + `tools/export-db-history.ps1`) to snapshot current SQL object DDL after migrations.
-- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). Further work is product-driven (auth, more metrics, UI).
+- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4). Further work is product-driven (**more metrics + catalog**, UI, or deployment hardening if plans change).
 
 ---
 
 ## 3. Recommended next step (small slice)
 
-**Do next:** Harden **`AnalyticsMetricsController`** for production (authentication, rate limits, or reverse-proxy only) if the host is internet-facing. Optionally add more **`IMetricExecutor`** registrations and extend **`MetricCatalog`** descriptions. Record a fresh **games/s** line in [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) when you change deriver/summary hot paths.
+**Do next:** Follow **[PLAN.md §12.4](./PLAN.md):** add **`IMetricExecutor`** implementations you care about, register them in **`IMetricRegistry`**, and improve **`GET /api/analytics/metrics`** discovery text (descriptions / hints). Add executor + API tests per new metric. Optionally refresh [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) if you change deriver or summary hot paths.
 
-**Why this order:** §12 checklist is complete; remaining risk is unauthenticated HTTP (PLAN §13).
+**Do not prioritize yet:** Dedicated HTTP **auth / rate limits** for `AnalyticsMetricsController` — **out of scope** until there is a **deployment or network exposure** plan (then treat as blocking; update PLAN §12.1 / §13). Optional hygiene: bind the dev host to **localhost** only.
 
 ---
 
@@ -61,7 +61,7 @@ Sync this subsection when items complete (or rely on `PLAN.md` checkboxes only �
 
 **CLI (Analyser, no web host):** `--backfill-analytics` (optional `--max-games N`); `--profile-materialization` (optional `--iterations N`, default 5000). Both exit after console output.
 
-**HTTP (Analyser web host):** `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute` — **no auth in v1 slice**; see controller remarks.
+**HTTP (Analyser web host):** `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute` — **no auth** while local-only; **defer** auth/rate limits until deployment (PLAN §12.4 / §13); see controller remarks.
 
 ---
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,7 +1,7 @@
 # ChessAnalyser — Board-position analytics (PLAN)
 
 **Location:** **`docs/`** — alongside [DESIGN.md](./DESIGN.md) and [AGENT_CONTEXT.md](./AGENT_CONTEXT.md).  
-**Document status:** Stage 2 (design guide) + **Stage 3 complete** (§11 checklist, 2026-05-10) + **Stage 4 §12 checklist complete** (metrics HTTP API + DESIGN F-9 / Q7 alignment).  
+**Document status:** Stage 2 (design guide) + **Stage 3 complete** (§11 checklist, 2026-05-10) + **Stage 4 §12 checklist complete** (metrics HTTP API + DESIGN F-9 / Q7 alignment). **Active implementation direction:** §12.4 (extend metrics catalog and executors; HTTP auth **deferred** while the app stays local-only / undeployed).  
 **Authority:** Implements [DESIGN.md](./DESIGN.md). Update this plan when scope or decisions change.
 
 ---
@@ -251,7 +251,7 @@ Use this as the working backlog for stage 3 (IMPLEMENT).
 
 Items **1–13** are **complete** in source for the board-position analytics groundwork: migrations through `010`, ETL materialization, **`IMetricRegistry`** and reference executors, backfill and perf CLIs on `Analyser`, and `Migrations/README.md` / [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md). **§11 is frozen** as the historical implementation checklist.
 
-**Active backlog:** use **§12** below. For session handoff text, prefer [AGENT_CONTEXT.md](./AGENT_CONTEXT.md).
+**Active backlog:** use **§12** below (including **§12.4** for the current suggested slice). For session handoff text, prefer [AGENT_CONTEXT.md](./AGENT_CONTEXT.md).
 
 ---
 
@@ -269,7 +269,7 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 | Discovery | **`GET /api/analytics/metrics`** returning **`IMetricRegistry.MetricKeys`** (and optional short descriptions from a static map or XML comments). |
 | Response | JSON projection of **`AnalyticsTableResult`**: `columnNames` + `rows` (array of arrays, or array of objects keyed by column — pick one and document). |
 | Errors | **404** or **400** for unknown **`metricKey`**; **400** for malformed filters. |
-| Auth | **Out of scope for first slice** unless the repo already has a standard middleware — document “open in dev; lock down before production” in controller remarks or README. |
+| Auth | **Deferred** while the host is **solo, local-only, and not deployed** for shared or internet access — no dedicated auth work in the current phase. If the API is later exposed on a network or to other users, add auth (e.g. API key or reverse proxy) + rate limits and update §13. Until then, optional hygiene: bind the web host to **localhost** only in run configuration. |
 | OpenAPI | Reuse Swashbuckle; ensure DTOs use public properties for usable schemas. |
 
 ### 12.2 Implementation checklist (ordered)
@@ -286,6 +286,20 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 |-------|-------|
 | API | Happy path + unknown metric key + optional filter passthrough (mock registry). |
 
+### 12.4 Recommended next implementation slice (post–§12)
+
+**Decision (2026):** The maintainer uses the application **only on a local machine** with **no current plan** to deploy it or grant controlled network access. Under that threat model, **HTTP authentication and rate-limiting for `AnalyticsMetricsController` are not the next priority.**
+
+**Suggested next work (PR-sized, in order of value):**
+
+1. **Extend the metrics surface** — add **`IMetricExecutor`** implementations for additional questions you care about (same patterns as the two reference metrics: parameterized repository reads, tabular `AnalyticsTableResult` only). Register them in **`IMetricRegistry`** / DI.
+2. **Improve discovery** — enrich **`GET /api/analytics/metrics`** with clearer descriptions (and optional parameter hints) so Swagger and future UI stay usable as the catalog grows.
+3. **Tests** — per-metric executor tests with mocked **`IChessRepository`** (and API smoke tests for new keys), following §12.3.
+
+**Optional:** Record a fresh materialization throughput line in [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) when you change hot paths in the deriver or summary factory.
+
+**When auth becomes relevant:** If you deploy the host or open it beyond localhost, treat **auth + rate limits** (or documented reverse-proxy-only access) as a **blocking** task before wider use; update §12.1, §13, and [AGENT_CONTEXT.md](./AGENT_CONTEXT.md).
+
 ---
 
 ## 13. Risks and mitigations
@@ -295,7 +309,7 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 | Move derivation fails on edge games | Tests + soft-fail (skip row, log); optional `GameMoveQuality` column later. |
 | Large DB backfill time | Process game-by-game; optional parallelism with cap. |
 | Transaction size for huge games | Batch inserts inside per-game transaction or chunk by N plies (rare games > 500 plies). |
-| Unauthenticated metrics HTTP endpoint | Rate-limit, auth, or network restriction before production; document dev default in §12. |
+| Unauthenticated metrics HTTP endpoint | **Accepted for local-only solo use** (see §12.1, §12.4). Before **deployment or network exposure**, add rate limits, auth, or strict network restriction and document the chosen approach. |
 
 ---
 
@@ -307,4 +321,4 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 
 ---
 
-*End of PLAN.md. Stage 3 (§11) is complete; Stage 4 follows **§12** with continuous alignment to [DESIGN.md](./DESIGN.md).*
+*End of PLAN.md. Stage 3 (§11) is complete; Stage 4 **§12** is complete; follow **§12.4** for the current suggested metrics work until deployment plans change.*

--- a/src/Analyser/Controllers/AnalyticsMetricsController.cs
+++ b/src/Analyser/Controllers/AnalyticsMetricsController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Analyser.Controllers;
 
 /// <summary>
-/// HTTP surface for registered analytics metrics (<see cref="IMetricRegistry"/>). **No authentication in this slice** — restrict by network or add auth before production (PLAN §12 / §13).
+/// HTTP surface for registered analytics metrics (<see cref="IMetricRegistry"/>). **No authentication** while the host is local-only; add auth / rate limits before network deployment (see PLAN §12.1, §12.4, §13).
 /// </summary>
 [ApiController]
 [Route("api/analytics/metrics")]


### PR DESCRIPTION
## Summary

Documents that the metrics HTTP API stays **unauthenticated** while the app is used **solo and local-only**, and redirects the implementation focus to **§12.4** (extend metrics and discovery) instead of auth hardening until there is a deployment or network-exposure plan.

## Changes

- **`docs/PLAN.md`:** New **§12.4** (recommended next slice); **§12.1** auth row and **§13** risk table updated; document status and closing line aligned.
- **`docs/AGENT_CONTEXT.md`:** Recommended next step and HTTP notes updated to match PLAN (auth deferred; metrics extension prioritized).
- **`AnalyticsMetricsController.cs`:** XML summary updated to point at PLAN §12.1 / §12.4 / §13 instead of implying immediate production lock-down.

## How to test

- Documentation-only PR; no code-path changes. Optional: open the three files and confirm wording matches your intended stance (local-only vs future deployment).

## Notes

No runtime or API contract changes. When you later expose the host beyond localhost, treat auth + rate limits as a dedicated follow-up and revise PLAN §12.1 / §13 again.