### PR TITLE
feat(analytics): add ECO counts and name-based player filters.

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -37,7 +37,7 @@ The framework should make it **easy to add new metrics** and **efficient to run 
 |----|-------------|--------|
 | F-1 | **Board-state metrics (“material” and counts)** | At each ply, support metrics over **what is on the board**: total piece value by colour, **per-piece-type counts** (e.g. knights on the board), and any combination of dimensions (player, year, ply index, colour, etc.). Examples: “at ply 4, average total material for White’s side for player X”; “at ply 4, average number of knights, globally and split White/Black.” **Configurable** piece values for value-based totals. |
 | F-2 | **Move / piece-frequency metrics** | Support statistics on **how often** certain events occur: e.g. piece type P moved to square S, captures, promotions (if derivable), etc., filterable by player, year, colour, ECO, etc. |
-| F-3 | **Dimensional filtering** | All public metrics must support **combinations** of filters (e.g. `Year = 1938 AND WhitePlayerId = 42 AND PlyIndex BETWEEN 0 AND 40`). |
+| F-3 | **Dimensional filtering** | All public metrics must support **combinations** of filters (e.g. `Year = 1938 AND WhitePlayer = "Capablanca, Jose Raul" AND PlyIndex BETWEEN 0 AND 40`). |
 | F-4 | **Aggregation** | Support **COUNT**, **SUM**, **AVG**, **MIN**, **MAX** where semantically valid; extensible registry for custom reducers if needed later. |
 | F-5 | **Grouping** | Support **GROUP BY** one or more dimensions (year, player, ECO bucket, decile of ply, etc.). |
 | F-6 | **Extensibility** | New statistic types should be addable **without** modifying unrelated metrics (plugin-like or registry pattern; see §6). |
@@ -58,7 +58,7 @@ Dimensions should be **first-class** in the design even if not all are implement
 | Dimension | Source (conceptual) | Resolution / notes |
 |-----------|---------------------|---------------------|
 | Game | `Game` | GameId, Name, Result/Winner, etc. |
-| White player / Black player | `Game.WhitePlayerId`, `BlackPlayerId` → `Player` | Ingest-time resolution; analytics use **canonical Id**. |
+| White player / Black player | `Game.WhitePlayerId`, `BlackPlayerId` → `Player` | Ingest-time resolution stores canonical IDs; public filters use player surname/forenames so users do not need database IDs. |
 | Calendar **year** | **Explicit column** on `Game` (see §3.5) | Games with **incomplete/unknown** PGN dates are **omitted** from any analysis or grouping that depends on year (no “unknown year” bucket unless added later as a separate requirement). |
 | Ply | `BoardPosition.PlyIndex` | **Unit of aggregation for moves and position stats: one ply** (half-move). Aligns with colour/player differentiation; not “full move” (White+Black). |
 | Colour / side | Derived from schema + ply convention | Document in PLAN/implementations and tests (NFR-5). |

--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -43,7 +43,7 @@ SELECT TOP 20
     DateTag,
     GameYear,
     Eco,
-    WhitePlayerId,
+    WhitePlayerId, -- storage FK; UI/API filters use player surname/forenames
     BlackPlayerId
 FROM dbo.[Game]
 ORDER BY Id DESC;
@@ -101,6 +101,7 @@ Current metric keys:
 
 - `AverageMaterialByYearAndColour`
 - `KnightMoveDestinationFrequency`
+- `GameCountByEco`
 
 Both support the shared `AnalyticsQuery` filter shape:
 
@@ -108,8 +109,10 @@ Both support the shared `AnalyticsQuery` filter shape:
 {
   "minGameYear": 1900,
   "maxGameYear": 1950,
-  "whitePlayerId": null,
-  "blackPlayerId": null,
+  "whitePlayerSurname": null,
+  "whitePlayerForenames": null,
+  "blackPlayerSurname": null,
+  "blackPlayerForenames": null,
   "eco": null,
   "summaryPlyIndex": 4
 }
@@ -138,7 +141,7 @@ In **Analytics metrics**:
 
 - Metric key: `AverageMaterialByYearAndColour`
 - `summaryPlyIndex`: `4` (or leave empty for the default)
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, `whitePlayerId`, or `blackPlayerId`
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
 
 Click **Run metric**.
 
@@ -192,7 +195,7 @@ checking whether move derivation is working and for exploring opening or player 
 In **Analytics metrics**:
 
 - Metric key: `KnightMoveDestinationFrequency`
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, `whitePlayerId`, or `blackPlayerId`
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
 
 Click **Run metric**.
 
@@ -229,7 +232,56 @@ Content-Type: application/json
 
 ---
 
-## 6. Example analysis: browse the game population
+## 6. Example analysis: game count by ECO
+
+### Question
+
+Which ECO codes occur most often in the loaded game set?
+
+### Why it is useful
+
+This is a fast corpus-shape metric. It helps you see which openings dominate the data and is easy
+to verify against `dbo.Game`.
+
+### Run it in the UI
+
+In **Analytics metrics**:
+
+- Metric key: `GameCountByEco`
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+
+Click **Run metric**.
+
+### Equivalent HTTP request
+
+```http
+POST /api/analytics/metrics/execute
+Content-Type: application/json
+```
+
+```json
+{
+  "metricKey": "GameCountByEco",
+  "query": {
+    "minGameYear": 1900,
+    "maxGameYear": 1950
+  }
+}
+```
+
+### Result columns
+
+- `Eco`
+- `GameCount`
+
+### Notes
+
+- Games with missing or blank `Eco` are excluded.
+- Supplying `eco` narrows the result to that exact code, which is mostly useful as a quick check.
+
+---
+
+## 7. Example analysis: browse the game population
 
 ### Question
 
@@ -241,7 +293,7 @@ In **Games (paged)**:
 
 - `page`: `1`
 - `pageSize`: `50`
-- Optional filters: `minGameYear`, `maxGameYear`, `whitePlayerId`, `blackPlayerId`, `eco`
+- Optional filters: `minGameYear`, `maxGameYear`, White/Black player names, `eco`
 
 Click **Fetch page**.
 
@@ -254,12 +306,12 @@ GET /Analyser/GetGames?page=1&pageSize=50&minGameYear=1900&maxGameYear=1950
 ### What to look for
 
 - `event`, `site`, `dateTag`, `gameYear`, and `eco` are populated where the PGN has those tags.
-- `whitePlayerId` and `blackPlayerId` are present when player resolution succeeded.
+- White/Black player names in the UI are populated from the resolved `Player` rows.
 - Page counts look reasonable for your loaded PGN set.
 
 ---
 
-## 7. Useful SQL checks
+## 8. Useful SQL checks
 
 Use these as diagnostics, not as the primary application surface.
 
@@ -302,7 +354,7 @@ ORDER BY g.Id;
 
 ---
 
-## 8. Adding a new example analysis to this document
+## 9. Adding a new example analysis to this document
 
 Use this template:
 
@@ -343,7 +395,7 @@ When adding a new metric implementation, update:
 
 ---
 
-## 9. Known limitations and next improvements
+## 10. Known limitations and next improvements
 
 - The current web UI is intentionally simple static HTML/JavaScript.
 - Metric outputs are tabular, not charted.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -265,7 +265,7 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 
 | Concern | Decision |
 |---------|----------|
-| Execute | **`POST /api/analytics/metrics/execute`** (or `…/run`) with body `{ "metricKey": "…", "query": { … } }` mapping to **`AnalyticsQuery`** (`MinGameYear`, `MaxGameYear`, `WhitePlayerId`, `BlackPlayerId`, `Eco`, `SummaryPlyIndex`). |
+| Execute | **`POST /api/analytics/metrics/execute`** (or `…/run`) with body `{ "metricKey": "…", "query": { … } }` mapping to **`AnalyticsQuery`** (`MinGameYear`, `MaxGameYear`, `WhitePlayerSurname`, `WhitePlayerForenames`, `BlackPlayerSurname`, `BlackPlayerForenames`, `Eco`, `SummaryPlyIndex`). |
 | Discovery | **`GET /api/analytics/metrics`** returning **`IMetricRegistry.MetricKeys`** (and optional short descriptions from a static map or XML comments). |
 | Response | JSON projection of **`AnalyticsTableResult`**: `columnNames` + `rows` (array of arrays, or array of objects keyed by column — pick one and document). |
 | Errors | **404** or **400** for unknown **`metricKey`**; **400** for malformed filters. |

--- a/src/Analyser/Controllers/AnalyserController.cs
+++ b/src/Analyser/Controllers/AnalyserController.cs
@@ -114,6 +114,8 @@ public class AnalyserController(
             .Select(p => new PlayerOptionResponse
             {
                 Id = p.Id,
+                Surname = p.Surname?.Trim() ?? string.Empty,
+                Forenames = p.Forenames?.Trim() ?? string.Empty,
                 DisplayName = FormatPlayerDisplayName(p)
             })
             .ToList();
@@ -129,8 +131,10 @@ public class AnalyserController(
     /// <param name="pageSize">Rows per page (1–500).</param>
     /// <param name="minGameYear">Lower bound on <c>GameYear</c> (inclusive).</param>
     /// <param name="maxGameYear">Upper bound on <c>GameYear</c> (inclusive).</param>
-    /// <param name="whitePlayerId">Exact match on <c>WhitePlayerId</c>.</param>
-    /// <param name="blackPlayerId">Exact match on <c>BlackPlayerId</c>.</param>
+    /// <param name="whitePlayerSurname">Exact match on White player's surname.</param>
+    /// <param name="whitePlayerForenames">Exact match on White player's forenames. Empty string matches blank forenames.</param>
+    /// <param name="blackPlayerSurname">Exact match on Black player's surname.</param>
+    /// <param name="blackPlayerForenames">Exact match on Black player's forenames. Empty string matches blank forenames.</param>
     /// <param name="eco">Exact match on persisted <c>Eco</c> (trimmed, max 16 characters).</param>
     /// <param name="cancellationToken">Propagates cancellation from the client.</param>
     [HttpGet("GetGames")]
@@ -140,8 +144,10 @@ public class AnalyserController(
         [FromQuery] int pageSize = 50,
         [FromQuery] short? minGameYear = null,
         [FromQuery] short? maxGameYear = null,
-        [FromQuery] int? whitePlayerId = null,
-        [FromQuery] int? blackPlayerId = null,
+        [FromQuery] string? whitePlayerSurname = null,
+        [FromQuery] string? whitePlayerForenames = null,
+        [FromQuery] string? blackPlayerSurname = null,
+        [FromQuery] string? blackPlayerForenames = null,
         [FromQuery] string? eco = null,
         CancellationToken cancellationToken = default)
     {
@@ -156,19 +162,44 @@ public class AnalyserController(
         if (ecoTrimmed != null && ecoTrimmed.Length > 16)
             return BadRequest("eco must be at most 16 characters after trimming.");
 
-        GamePageFilters? filters = minGameYear.HasValue || maxGameYear.HasValue || whitePlayerId.HasValue || blackPlayerId.HasValue || ecoTrimmed != null
+        var whiteSurname = NormalizeOptional(whitePlayerSurname);
+        var whiteForenames = NormalizeOptionalAllowEmpty(whitePlayerForenames);
+        var blackSurname = NormalizeOptional(blackPlayerSurname);
+        var blackForenames = NormalizeOptionalAllowEmpty(blackPlayerForenames);
+
+        GamePageFilters? filters = minGameYear.HasValue
+                                    || maxGameYear.HasValue
+                                    || whiteSurname != null
+                                    || blackSurname != null
+                                    || ecoTrimmed != null
             ? new GamePageFilters
             {
                 MinGameYear = minGameYear,
                 MaxGameYear = maxGameYear,
-                WhitePlayerId = whitePlayerId,
-                BlackPlayerId = blackPlayerId,
+                WhitePlayerSurname = whiteSurname,
+                WhitePlayerForenames = whiteSurname == null ? null : whiteForenames,
+                BlackPlayerSurname = blackSurname,
+                BlackPlayerForenames = blackSurname == null ? null : blackForenames,
                 Eco = ecoTrimmed
             }
             : null;
 
         var pageResult = await _chessRepository.GetGamesPage(page, pageSize, filters, cancellationToken).ConfigureAwait(false);
         return Ok(pageResult);
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return value.Trim();
+    }
+
+    private static string? NormalizeOptionalAllowEmpty(string? value)
+    {
+        if (value == null)
+            return null;
+        return value.Trim();
     }
 
     private static string FormatPlayerDisplayName(Player player)

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -16,6 +16,8 @@ internal static class MetricCatalog
                 "Average WhiteMaterial and BlackMaterial from GamePositionSummary at a fixed ply, grouped by GameYear (games with null year excluded).",
             "KnightMoveDestinationFrequency" =>
                 "Count of knight half-moves grouped by destination square (ToSquare), with optional Game filters.",
+            "GameCountByEco" =>
+                "Count of games grouped by ECO code, with optional year, player-name, and ECO filters.",
             _ => null
         };
     }

--- a/src/Analyser/Models/PlayerOptionResponse.cs
+++ b/src/Analyser/Models/PlayerOptionResponse.cs
@@ -7,5 +7,9 @@ public sealed class PlayerOptionResponse
 {
     public int Id { get; init; }
 
+    public required string Surname { get; init; }
+
+    public required string Forenames { get; init; }
+
     public required string DisplayName { get; init; }
 }

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -84,6 +84,7 @@ builder.Services.AddScoped<IGameMoveDeriver, GameMoveDeriver>();
 builder.Services.AddScoped<IAnalyticsMaterializationService, AnalyticsMaterializationService>();
 builder.Services.AddScoped<IMetricExecutor, AverageMaterialByYearAndColourExecutor>();
 builder.Services.AddScoped<IMetricExecutor, KnightMoveDestinationFrequencyExecutor>();
+builder.Services.AddScoped<IMetricExecutor, GameCountByEcoExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -152,6 +152,7 @@
       var base = window.location.origin;
       var analyser = base + '/Analyser';
       var analytics = base + '/api/analytics/metrics';
+      var playersById = {};
 
       function parseJsonSafe(response) {
         return response.text().then(function (text) {
@@ -183,6 +184,16 @@
         return t === '' ? null : t;
       }
 
+      function selectedPlayer(id) {
+        var select = document.getElementById(id);
+        if (!select || select.selectedIndex < 0 || !select.value) return null;
+        var opt = select.options[select.selectedIndex];
+        return {
+          surname: opt.dataset.surname || '',
+          forenames: opt.dataset.forenames || ''
+        };
+      }
+
       function populatePlayerSelect(select, players) {
         select.innerHTML = '';
 
@@ -193,8 +204,10 @@
 
         players.forEach(function (p) {
           var opt = document.createElement('option');
-          opt.value = String(p.id);
+          opt.value = p.displayName || (p.surname || ('Player ' + p.id));
           opt.textContent = p.displayName || ('Player ' + p.id);
+          opt.dataset.surname = p.surname || '';
+          opt.dataset.forenames = p.forenames || '';
           select.appendChild(opt);
         });
       }
@@ -218,6 +231,10 @@
             return r.json();
           })
           .then(function (players) {
+            playersById = {};
+            (players || []).forEach(function (p) {
+              playersById[p.id] = p.displayName || (p.surname || ('Player ' + p.id));
+            });
             selects.forEach(function (select) {
               populatePlayerSelect(select, players || []);
               select.disabled = false;
@@ -342,14 +359,20 @@
         var q = {};
         var a = numVal('qMinYear');
         var b = numVal('qMaxYear');
-        var w = numVal('qWhite');
-        var bl = numVal('qBlack');
+        var w = selectedPlayer('qWhite');
+        var bl = selectedPlayer('qBlack');
         var eco = strVal('qEco');
         var ply = numVal('qPly');
         if (a != null) q.minGameYear = a;
         if (b != null) q.maxGameYear = b;
-        if (w != null) q.whitePlayerId = w;
-        if (bl != null) q.blackPlayerId = bl;
+        if (w != null) {
+          q.whitePlayerSurname = w.surname;
+          q.whitePlayerForenames = w.forenames;
+        }
+        if (bl != null) {
+          q.blackPlayerSurname = bl.surname;
+          q.blackPlayerForenames = bl.forenames;
+        }
         if (eco != null) q.eco = eco;
         if (ply != null) q.summaryPlyIndex = ply;
         return Object.keys(q).length ? q : undefined;
@@ -450,13 +473,19 @@
         params.set('pageSize', String(pageSize));
         var my = numVal('gMinYear');
         var Mx = numVal('gMaxYear');
-        var gw = numVal('gWhite');
-        var gb = numVal('gBlack');
+        var gw = selectedPlayer('gWhite');
+        var gb = selectedPlayer('gBlack');
         var ge = strVal('gEco');
         if (my != null) params.set('minGameYear', String(my));
         if (Mx != null) params.set('maxGameYear', String(Mx));
-        if (gw != null) params.set('whitePlayerId', String(gw));
-        if (gb != null) params.set('blackPlayerId', String(gb));
+        if (gw != null) {
+          params.set('whitePlayerSurname', gw.surname);
+          params.set('whitePlayerForenames', gw.forenames);
+        }
+        if (gb != null) {
+          params.set('blackPlayerSurname', gb.surname);
+          params.set('blackPlayerForenames', gb.forenames);
+        }
         if (ge != null) params.set('eco', ge);
         gamesStatus.textContent = 'Loading…';
         gamesStatus.className = 'status';
@@ -476,11 +505,20 @@
               gamesTableWrap.innerHTML = '<p class="hint">No rows.</p>';
               return;
             }
-            var cols = ['id', 'name', 'gameYear', 'eco', 'event', 'whitePlayerId', 'blackPlayerId', 'gameId'];
-            var th = cols.map(function (c) { return '<th>' + c + '</th>'; }).join('');
+            var cols = [
+              { key: 'id', label: 'id' },
+              { key: 'name', label: 'name' },
+              { key: 'gameYear', label: 'gameYear' },
+              { key: 'eco', label: 'eco' },
+              { key: 'event', label: 'event' },
+              { key: 'whitePlayerId', label: 'whitePlayer', display: function (g) { return playersById[g.whitePlayerId] || ''; } },
+              { key: 'blackPlayerId', label: 'blackPlayer', display: function (g) { return playersById[g.blackPlayerId] || ''; } },
+              { key: 'gameId', label: 'gameId' }
+            ];
+            var th = cols.map(function (c) { return '<th>' + c.label + '</th>'; }).join('');
             var trs = data.items.map(function (g) {
               var tds = cols.map(function (c) {
-                var v = g[c];
+                var v = c.display ? c.display(g) : g[c.key];
                 return '<td>' + escapeHtml(v === null || v === undefined ? '' : v) + '</td>';
               }).join('');
               return '<tr>' + tds + '</tr>';

--- a/src/Interfaces/Analytics/AnalyticsQuery.cs
+++ b/src/Interfaces/Analytics/AnalyticsQuery.cs
@@ -9,9 +9,17 @@ public sealed class AnalyticsQuery
 
     public short? MaxGameYear { get; init; }
 
-    public int? WhitePlayerId { get; init; }
+    /// <summary>Exact match on White player's surname when set.</summary>
+    public string? WhitePlayerSurname { get; init; }
 
-    public int? BlackPlayerId { get; init; }
+    /// <summary>Exact match on White player's forenames when set. Empty string matches players with no forenames.</summary>
+    public string? WhitePlayerForenames { get; init; }
+
+    /// <summary>Exact match on Black player's surname when set.</summary>
+    public string? BlackPlayerSurname { get; init; }
+
+    /// <summary>Exact match on Black player's forenames when set. Empty string matches players with no forenames.</summary>
+    public string? BlackPlayerForenames { get; init; }
 
     /// <summary>Exact match on <c>dbo.Game.Eco</c> when set.</summary>
     public string? Eco { get; init; }

--- a/src/Interfaces/Analytics/GameCountByEcoRow.cs
+++ b/src/Interfaces/Analytics/GameCountByEcoRow.cs
@@ -1,0 +1,8 @@
+namespace Interfaces.Analytics;
+
+public sealed class GameCountByEcoRow
+{
+    public string Eco { get; init; } = string.Empty;
+
+    public int GameCount { get; init; }
+}

--- a/src/Interfaces/DTO/GamePageFilters.cs
+++ b/src/Interfaces/DTO/GamePageFilters.cs
@@ -9,9 +9,13 @@ public sealed class GamePageFilters
 
     public short? MaxGameYear { get; init; }
 
-    public int? WhitePlayerId { get; init; }
+    public string? WhitePlayerSurname { get; init; }
 
-    public int? BlackPlayerId { get; init; }
+    public string? WhitePlayerForenames { get; init; }
+
+    public string? BlackPlayerSurname { get; init; }
+
+    public string? BlackPlayerForenames { get; init; }
 
     /// <summary>Exact match on persisted <c>Eco</c> (max 16 characters in DB).</summary>
     public string? Eco { get; init; }

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -80,6 +80,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Counts games by ECO code with optional game filters.
+        /// </summary>
+        Task<IReadOnlyList<GameCountByEcoRow>> GetGameCountsByEcoAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -117,13 +124,15 @@ namespace Repositories
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
             var offset = (page - 1) * pageSize;
-            var eco = NormalizeEco(filters?.Eco);
+            var eco = NormalizeNonEmpty(filters?.Eco);
             var filterParams = new
             {
                 MinGameYear = filters?.MinGameYear,
                 MaxGameYear = filters?.MaxGameYear,
-                WhitePlayerId = filters?.WhitePlayerId,
-                BlackPlayerId = filters?.BlackPlayerId,
+                WhitePlayerSurname = filters?.WhitePlayerSurname,
+                WhitePlayerForenames = filters?.WhitePlayerForenames,
+                BlackPlayerSurname = filters?.BlackPlayerSurname,
+                BlackPlayerForenames = filters?.BlackPlayerForenames,
                 Eco = eco,
                 Offset = offset,
                 PageSize = pageSize
@@ -131,14 +140,16 @@ namespace Repositories
 
             const string whereClause =
                 """
-                WHERE (@MinGameYear IS NULL OR [GameYear] >= @MinGameYear)
-                  AND (@MaxGameYear IS NULL OR [GameYear] <= @MaxGameYear)
-                  AND (@WhitePlayerId IS NULL OR [WhitePlayerId] = @WhitePlayerId)
-                  AND (@BlackPlayerId IS NULL OR [BlackPlayerId] = @BlackPlayerId)
-                  AND (@Eco IS NULL OR [Eco] = @Eco)
+                LEFT JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR g.[GameYear] >= @MinGameYear)
+                  AND (@MaxGameYear IS NULL OR g.[GameYear] <= @MaxGameYear)
+                  AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
+                  AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+                  AND (@Eco IS NULL OR g.[Eco] = @Eco)
                 """;
 
-            var countSql = "SELECT COUNT(1) FROM dbo.[Game] " + whereClause;
+            var countSql = "SELECT COUNT(1) FROM dbo.[Game] g " + whereClause;
             var countCmd = new CommandDefinition(
                 countSql,
                 filterParams,
@@ -148,9 +159,9 @@ namespace Repositories
 
             var pageSql =
                 """
-                SELECT * FROM dbo.[Game]
+                SELECT g.* FROM dbo.[Game] g
                 """ + whereClause + """
-                ORDER BY [Id]
+                ORDER BY g.[Id]
                 OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY
                 """;
             var pageCmd = new CommandDefinition(
@@ -169,12 +180,19 @@ namespace Repositories
             };
         }
 
-        private static string? NormalizeEco(string? eco)
+        private static string? NormalizeNonEmpty(string? value)
         {
-            if (string.IsNullOrWhiteSpace(eco))
+            if (string.IsNullOrWhiteSpace(value))
                 return null;
-            var t = eco.Trim();
+            var t = value.Trim();
             return t.Length == 0 ? null : t;
+        }
+
+        private static string? NormalizeNamePart(string? value)
+        {
+            if (value == null)
+                return null;
+            return value.Trim();
         }
 
         /// <summary>
@@ -512,8 +530,10 @@ namespace Repositories
                         PlyIndex = plyIndex,
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerId = query.WhitePlayerId,
-                        BlackPlayerId = query.BlackPlayerId,
+                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
+                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
+                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
+                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
                         Eco = query.Eco
                     },
                     cancellationToken: cancellationToken))).ToList();
@@ -535,9 +555,36 @@ namespace Repositories
                     {
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerId = query.WhitePlayerId,
-                        BlackPlayerId = query.BlackPlayerId,
+                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
+                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
+                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
+                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
                         Eco = query.Eco
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<GameCountByEcoRow>> GetGameCountsByEcoAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<GameCountByEcoRow>(
+                new CommandDefinition(
+                    SqlStatements.GetGameCountsByEco,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
+                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
+                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
+                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();
 

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -109,11 +109,13 @@ namespace Repositories
                    COUNT(*) AS GameCount
             FROM dbo.Game g
             INNER JOIN dbo.GamePositionSummary s ON s.GameId = g.Id AND s.PlyIndex = @PlyIndex
+            LEFT JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+            LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
             WHERE g.GameYear IS NOT NULL
               AND (@MinGameYear IS NULL OR g.GameYear >= @MinGameYear)
               AND (@MaxGameYear IS NULL OR g.GameYear <= @MaxGameYear)
-              AND (@WhitePlayerId IS NULL OR g.WhitePlayerId = @WhitePlayerId)
-              AND (@BlackPlayerId IS NULL OR g.BlackPlayerId = @BlackPlayerId)
+              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
+              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
               AND (@Eco IS NULL OR g.Eco = @Eco)
             GROUP BY g.GameYear
             ORDER BY g.GameYear;
@@ -127,14 +129,36 @@ namespace Repositories
             SELECT m.ToSquare AS ToSquare, COUNT(*) AS MoveCount
             FROM dbo.GameMove m
             INNER JOIN dbo.Game g ON g.Id = m.GameId
+            LEFT JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+            LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
             WHERE m.MovedPiece = 'N'
               AND (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
               AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
-              AND (@WhitePlayerId IS NULL OR g.WhitePlayerId = @WhitePlayerId)
-              AND (@BlackPlayerId IS NULL OR g.BlackPlayerId = @BlackPlayerId)
+              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
+              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
               AND (@Eco IS NULL OR g.Eco = @Eco)
             GROUP BY m.ToSquare
             ORDER BY MoveCount DESC, m.ToSquare;
+            """;
+
+        /// <summary>
+        /// Games grouped by ECO code; optional filters on year, player names, and ECO.
+        /// </summary>
+        public static string GetGameCountsByEco =>
+            """
+            SELECT g.Eco AS Eco, COUNT(*) AS GameCount
+            FROM dbo.Game g
+            LEFT JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+            LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+            WHERE g.Eco IS NOT NULL
+              AND LTRIM(RTRIM(g.Eco)) <> ''
+              AND (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+              AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
+              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+              AND (@Eco IS NULL OR g.Eco = @Eco)
+            GROUP BY g.Eco
+            ORDER BY GameCount DESC, g.Eco;
             """;
 
         /// <summary>

--- a/src/Services/Analytics/GameCountByEcoExecutor.cs
+++ b/src/Services/Analytics/GameCountByEcoExecutor.cs
@@ -1,0 +1,29 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Counts games by ECO code with the shared game filters.
+/// </summary>
+public sealed class GameCountByEcoExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "GameCountByEco";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var rows = await _repository.GetGameCountsByEcoAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(GameCountByEcoRow r) =>
+            new object?[] { r.Eco, r.GameCount };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Eco", "GameCount"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -50,6 +50,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<KnightDestinationCountRow>>();
 
+    public Task<IReadOnlyList<GameCountByEcoRow>> GetGameCountsByEcoAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<GameCountByEcoRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/AnalyserTests/AnalyserControllerTests.cs
+++ b/test/AnalyserTests/AnalyserControllerTests.cs
@@ -116,6 +116,8 @@ namespace ControllerTests
             var ok = Assert.IsType<OkObjectResult>(result);
             var options = Assert.IsType<List<PlayerOptionResponse>>(ok.Value);
             Assert.Equal([1, 3, 2], options.Select(o => o.Id).ToArray());
+            Assert.Equal("Botvinnik", options[0].Surname);
+            Assert.Equal("Mikhail", options[0].Forenames);
             Assert.Equal("Botvinnik, Mikhail", options[0].DisplayName);
             Assert.Equal("Capablanca", options[1].DisplayName);
             Assert.Equal("Tal, Mikhail", options[2].DisplayName);
@@ -170,8 +172,10 @@ namespace ControllerTests
                         f != null
                         && f.MinGameYear == 1990
                         && f.MaxGameYear == 2000
-                        && f.WhitePlayerId == 3
-                        && f.BlackPlayerId == 7
+                        && f.WhitePlayerSurname == "Kasparov"
+                        && f.WhitePlayerForenames == "Garry"
+                        && f.BlackPlayerSurname == "Karpov"
+                        && f.BlackPlayerForenames == "Anatoly"
                         && f.Eco == "B90"),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(page);
@@ -187,7 +191,16 @@ namespace ControllerTests
                 scopeFactoryMock.Object,
                 pgnOptions);
 
-            await controller.GetGames(1, 10, 1990, 2000, 3, 7, "B90");
+            await controller.GetGames(
+                1,
+                10,
+                1990,
+                2000,
+                "Kasparov",
+                "Garry",
+                "Karpov",
+                "Anatoly",
+                "B90");
 
             chessRepoMock.Verify(
                 r => r.GetGamesPage(
@@ -197,8 +210,10 @@ namespace ControllerTests
                         f != null
                         && f.MinGameYear == 1990
                         && f.MaxGameYear == 2000
-                        && f.WhitePlayerId == 3
-                        && f.BlackPlayerId == 7
+                        && f.WhitePlayerSurname == "Kasparov"
+                        && f.WhitePlayerForenames == "Garry"
+                        && f.BlackPlayerSurname == "Karpov"
+                        && f.BlackPlayerForenames == "Anatoly"
                         && f.Eco == "B90"),
                     It.IsAny<CancellationToken>()),
                 Times.Once);

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -15,16 +15,20 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<MaterialAverageByYearRow>());
         repo.Setup(r => r.GetKnightDestinationCountsAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<KnightDestinationCountRow>());
+        repo.Setup(r => r.GetGameCountsByEcoAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<GameCountByEcoRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
             new AverageMaterialByYearAndColourExecutor(repo.Object),
-            new KnightMoveDestinationFrequencyExecutor(repo.Object)
+            new KnightMoveDestinationFrequencyExecutor(repo.Object),
+            new GameCountByEcoExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
         Assert.Contains("KnightMoveDestinationFrequency", sut.MetricKeys);
-        Assert.Equal(2, sut.MetricKeys.Count);
+        Assert.Contains("GameCountByEco", sut.MetricKeys);
+        Assert.Equal(3, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -115,12 +119,63 @@ public class MetricRegistryAndExecutorsTests
         repo.Setup(r => r.GetKnightDestinationCountsAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<KnightDestinationCountRow>());
 
-        var query = new AnalyticsQuery { MinGameYear = 2000, Eco = "C00" };
+        var query = new AnalyticsQuery { MinGameYear = 2000, Eco = "C00", WhitePlayerSurname = "Tal", WhitePlayerForenames = "Mikhail" };
         var sut = new KnightMoveDestinationFrequencyExecutor(repo.Object);
         await sut.ExecuteAsync(query);
 
         repo.Verify(r => r.GetKnightDestinationCountsAsync(
-            It.Is<AnalyticsQuery>(q => q.MinGameYear == 2000 && q.Eco == "C00"),
+            It.Is<AnalyticsQuery>(q =>
+                q.MinGameYear == 2000
+                && q.Eco == "C00"
+                && q.WhitePlayerSurname == "Tal"
+                && q.WhitePlayerForenames == "Mikhail"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GameCountByEcoExecutor_MapsRows()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetGameCountsByEcoAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GameCountByEcoRow>
+            {
+                new() { Eco = "B90", GameCount = 12 },
+                new() { Eco = "C00", GameCount = 5 }
+            });
+
+        var sut = new GameCountByEcoExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery());
+
+        Assert.Equal(["Eco", "GameCount"], result.ColumnNames);
+        Assert.Equal(2, result.Rows.Count);
+        Assert.Equal("B90", result.Rows[0][0]);
+        Assert.Equal(12, result.Rows[0][1]);
+    }
+
+    [Fact]
+    public async Task GameCountByEcoExecutor_PassesNameFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetGameCountsByEcoAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<GameCountByEcoRow>());
+
+        var query = new AnalyticsQuery
+        {
+            MinGameYear = 1980,
+            WhitePlayerSurname = "Kasparov",
+            WhitePlayerForenames = "Garry",
+            Eco = "B90"
+        };
+        var sut = new GameCountByEcoExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetGameCountsByEcoAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.MinGameYear == 1980
+                && q.WhitePlayerSurname == "Kasparov"
+                && q.WhitePlayerForenames == "Garry"
+                && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `GameCountByEco` metric and changes player filtering so users filter by player name parts instead of raw database IDs. The UI still uses player dropdowns, but now submits surname/forenames to the API, while SQL joins through `Player` internally.

## Changes

- Added `GameCountByEco` metric (`Eco`, `GameCount`) with repository query, executor, DI registration, catalog description, and tests.
- Replaced public player filter inputs in `AnalyticsQuery` and `GamePageFilters` from `WhitePlayerId` / `BlackPlayerId` to `WhitePlayerSurname` / `WhitePlayerForenames` and `BlackPlayerSurname` / `BlackPlayerForenames`.
- Updated repository SQL to join `dbo.Player` and filter by surname/forenames while keeping player IDs as internal storage FKs.
- Updated the local UI player dropdowns so they display `Surname, Forenames` and submit player name parts rather than IDs.
- Updated the Games table to show player names instead of raw player IDs.
- Updated `DESIGN.md`, `PLAN.md`, and `EXAMPLE_ANALYSES.md` to reflect name-based player filters and document `GameCountByEco`.

## How to test

- `dotnet build ChessAnalyser.sln`
- `dotnet test test/AnalyserTests/ControllerTests.csproj`
- `dotnet test test/ServicesTests/ServicesTests.csproj`
- Run Analyser, hard-refresh the local UI, and confirm:
  - player filters are dropdowns with `Surname, Forenames`
  - filtering sends name-based query values
  - `GameCountByEco` appears in the metric list
  - running `GameCountByEco` returns `Eco` / `GameCount` rows

## Notes

Player IDs remain part of the database schema and DTO storage model. They are no longer exposed as the user-facing filter contract for metrics or paged game browsing.