### PR TITLE
docs: clarify average material metric semantics.

### DIFF
--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -103,7 +103,8 @@ Current metric keys:
 - `KnightMoveDestinationFrequency`
 - `GameCountByEco`
 
-Both support the shared `AnalyticsQuery` filter shape:
+Metrics support the shared `AnalyticsQuery` filter shape where the filter is meaningful for that
+metric:
 
 ```json
 {
@@ -122,18 +123,21 @@ Omit properties, or leave them blank in the UI, when you do not want that filter
 
 ---
 
-## 4. Example analysis: average material by year
+## 4. Example analysis: average side material by year
 
 ### Question
 
-How does average material on the board vary by year at an early fixed ply?
+How does average material for the White side and Black side vary by year at an early fixed ply?
 
 ### Why it is useful
 
-This is a basic board-state sanity check and a starting point for historical comparisons. At a low
-ply such as `4`, most games should still be near starting material unless early captures happened.
-Large or surprising differences can point to data issues, unusual PGN parsing, or interesting
-opening patterns.
+This is a corpus-level board-state sanity check and a starting point for historical comparisons. At
+a low ply such as `4`, most games should still be near starting material unless early captures
+happened. Large or surprising differences can point to data issues, unusual PGN parsing, or
+interesting opening patterns.
+
+This metric compares **sides in the selected game set**: average `WhiteMaterial` for those games
+and average `BlackMaterial` for those same games. It is not an independent player-comparison metric.
 
 ### Run it in the UI
 
@@ -141,7 +145,7 @@ In **Analytics metrics**:
 
 - Metric key: `AverageMaterialByYearAndColour`
 - `summaryPlyIndex`: `4` (or leave empty for the default)
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+- Optional: set `minGameYear`, `maxGameYear`, or `eco`
 
 Click **Run metric**.
 
@@ -175,6 +179,12 @@ Content-Type: application/json
 - Games with `GameYear = NULL` are excluded by year-based metrics.
 - `summaryPlyIndex = 4` means the board snapshot after ply 4 using this repo's ply convention.
 - Material uses the configured `IPieceValues` implementation (`ClassicalPieceValues` today).
+- Player filters only narrow the game set before the side averages are calculated. For example,
+  filtering White player to `Kasparov, Garry` compares Kasparov's White-side material with the
+  Black-side material of his opponents in those same games. It does **not** compare Kasparov against
+  an all-player baseline or against another player independently.
+- Use the planned player-comparison metric (PLAN §12.5) for player-vs-player or player-vs-baseline
+  material questions.
 
 ---
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -313,12 +313,12 @@ compare two players independently, nor does it compare a player against a corpus
 
 Implement player material comparison as a separate sequence of PRs:
 
-1. **Clarify the existing metric (docs/catalog only).**
+1. [x] **Clarify the existing metric (docs/catalog only).**
    - Keep **`AverageMaterialByYearAndColour`** as a corpus-oriented metric.
    - Update metric catalog / examples so it is described as “average side material by year”, not a
      player comparison tool.
    - Avoid implying that filtering by one player creates a fair independent comparison.
-2. **Add a new player-comparison metric.**
+2. [ ] **Add a new player-comparison metric.**
    - Indicative key: **`AverageMaterialByPlayerAtMove`** (final name can change during
      implementation).
    - Inputs:
@@ -333,7 +333,7 @@ Implement player material comparison as a separate sequence of PRs:
      - Player A vs Player B regardless of colour, when colour is **Any**.
    - Keep the DB model ply-based internally; translate user-facing move number to the appropriate
      `PlyIndex` in the metric or repository layer.
-3. **Add metric-specific UI affordances.**
+3. [ ] **Add metric-specific UI affordances.**
    - The generic metrics form should not try to make every filter meaningful for every metric.
    - When `AverageMaterialByPlayerAtMove` is selected, show player-comparison fields, colour mode,
      and move number wording that explains the internal ply convention.

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -13,7 +13,7 @@ internal static class MetricCatalog
         return metricKey.Trim() switch
         {
             "AverageMaterialByYearAndColour" =>
-                "Average WhiteMaterial and BlackMaterial from GamePositionSummary at a fixed ply, grouped by GameYear (games with null year excluded).",
+                "Corpus trend: average White-side and Black-side material at a fixed ply, grouped by GameYear. Not an independent player comparison metric.",
             "KnightMoveDestinationFrequency" =>
                 "Count of knight half-moves grouped by destination square (ToSquare), with optional Game filters.",
             "GameCountByEco" =>


### PR DESCRIPTION
## Summary

Clarifies that `AverageMaterialByYearAndColour` is a corpus/year side-material trend metric, not an independent player-comparison metric. This completes the first planned PLAN §12.5 slice before implementing a separate player material comparison metric.

## Changes

- Updated `MetricCatalog` description for `AverageMaterialByYearAndColour` to describe it as a corpus trend over White-side and Black-side material.
- Updated `docs/EXAMPLE_ANALYSES.md` to rename the example to "average side material by year" and explain the metric's player-filter limitations.
- Marked PLAN §12.5 item 1 as complete, leaving the separate player-comparison metric and metric-specific UI work as follow-ups.

## How to test

- `dotnet build src/Analyser/Analyser.csproj`

## Notes

No metric behavior changed in this PR. It only clarifies existing semantics so the current metric is not mistaken for player-vs-player or player-vs-baseline analysis.