### PR TITLE
feat(analytics): add player material comparison metric.

### DIFF
--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -102,6 +102,7 @@ Current metric keys:
 - `AverageMaterialByYearAndColour`
 - `KnightMoveDestinationFrequency`
 - `GameCountByEco`
+- `AverageMaterialByPlayerAtMove`
 
 Metrics support the shared `AnalyticsQuery` filter shape where the filter is meaningful for that
 metric:
@@ -115,6 +116,12 @@ metric:
   "blackPlayerSurname": null,
   "blackPlayerForenames": null,
   "eco": null,
+  "playerASurname": "Kasparov",
+  "playerAForenames": "Garry",
+  "playerBSurname": null,
+  "playerBForenames": null,
+  "playerColour": "Any",
+  "moveNumber": 1,
   "summaryPlyIndex": 4
 }
 ```
@@ -188,7 +195,74 @@ Content-Type: application/json
 
 ---
 
-## 5. Example analysis: knight destination frequency
+## 5. Example analysis: average material by player at move
+
+### Question
+
+How does one player's average material at a full move compare with another player, or with the
+all-player baseline?
+
+### Why it is useful
+
+This is the player-comparison material metric. Unlike `AverageMaterialByYearAndColour`, it compares
+player appearances independently, so Player A does not need to have played Player B.
+
+### Run it
+
+Until the UI has metric-specific fields, use Swagger or another HTTP client.
+
+Use metric key `AverageMaterialByPlayerAtMove` with:
+
+- `playerASurname` / `playerAForenames` (required)
+- optional `playerBSurname` / `playerBForenames`; omit Player B for the all-player baseline
+- `playerColour`: `Any`, `White`, or `Black` (defaults to `Any`)
+- `moveNumber`: full move number (defaults to `1`)
+- optional `minGameYear`, `maxGameYear`, `eco`
+
+### Equivalent HTTP request
+
+```http
+POST /api/analytics/metrics/execute
+Content-Type: application/json
+```
+
+```json
+{
+  "metricKey": "AverageMaterialByPlayerAtMove",
+  "query": {
+    "playerASurname": "Kasparov",
+    "playerAForenames": "Garry",
+    "playerBSurname": "Karpov",
+    "playerBForenames": "Anatoly",
+    "playerColour": "Any",
+    "moveNumber": 5,
+    "minGameYear": 1980,
+    "maxGameYear": 1990
+  }
+}
+```
+
+### Result columns
+
+- `Series` (`PlayerA`, `PlayerB`, or `AllPlayers`)
+- `Player`
+- `Colour`
+- `MoveNumber`
+- `PlyIndex`
+- `AvgMaterial`
+- `PositionCount`
+
+### Notes
+
+- User-facing `moveNumber` maps to `PlyIndex = (moveNumber * 2) - 1`, i.e. after Black's move for
+  that full move number.
+- `playerColour = Any` includes both White and Black appearances for the selected player(s).
+- If Player B is omitted, the comparison row is `AllPlayers`.
+- If Player A does not match any rows, the metric returns an empty result.
+
+---
+
+## 6. Example analysis: knight destination frequency
 
 ### Question
 
@@ -242,7 +316,7 @@ Content-Type: application/json
 
 ---
 
-## 6. Example analysis: game count by ECO
+## 7. Example analysis: game count by ECO
 
 ### Question
 
@@ -291,7 +365,7 @@ Content-Type: application/json
 
 ---
 
-## 7. Example analysis: browse the game population
+## 8. Example analysis: browse the game population
 
 ### Question
 
@@ -321,7 +395,7 @@ GET /Analyser/GetGames?page=1&pageSize=50&minGameYear=1900&maxGameYear=1950
 
 ---
 
-## 8. Useful SQL checks
+## 9. Useful SQL checks
 
 Use these as diagnostics, not as the primary application surface.
 
@@ -364,7 +438,7 @@ ORDER BY g.Id;
 
 ---
 
-## 9. Adding a new example analysis to this document
+## 10. Adding a new example analysis to this document
 
 Use this template:
 
@@ -405,7 +479,7 @@ When adding a new metric implementation, update:
 
 ---
 
-## 10. Known limitations and next improvements
+## 11. Known limitations and next improvements
 
 - The current web UI is intentionally simple static HTML/JavaScript.
 - Metric outputs are tabular, not charted.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -318,7 +318,7 @@ Implement player material comparison as a separate sequence of PRs:
    - Update metric catalog / examples so it is described as “average side material by year”, not a
      player comparison tool.
    - Avoid implying that filtering by one player creates a fair independent comparison.
-2. [ ] **Add a new player-comparison metric.**
+2. [x] **Add a new player-comparison metric.**
    - Indicative key: **`AverageMaterialByPlayerAtMove`** (final name can change during
      implementation).
    - Inputs:

--- a/src/Analyser/Controllers/AnalyticsMetricsController.cs
+++ b/src/Analyser/Controllers/AnalyticsMetricsController.cs
@@ -61,5 +61,9 @@ public sealed class AnalyticsMetricsController(IMetricRegistry metricRegistry) :
         {
             return NotFound($"Unknown metric key: {request.MetricKey.Trim()}");
         }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 }

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -18,6 +18,8 @@ internal static class MetricCatalog
                 "Count of knight half-moves grouped by destination square (ToSquare), with optional Game filters.",
             "GameCountByEco" =>
                 "Count of games grouped by ECO code, with optional year, player-name, and ECO filters.",
+            "AverageMaterialByPlayerAtMove" =>
+                "Average material at a full move for Player A compared with Player B, or all players, with colour mode Any/White/Black.",
             _ => null
         };
     }

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -85,6 +85,7 @@ builder.Services.AddScoped<IAnalyticsMaterializationService, AnalyticsMaterializ
 builder.Services.AddScoped<IMetricExecutor, AverageMaterialByYearAndColourExecutor>();
 builder.Services.AddScoped<IMetricExecutor, KnightMoveDestinationFrequencyExecutor>();
 builder.Services.AddScoped<IMetricExecutor, GameCountByEcoExecutor>();
+builder.Services.AddScoped<IMetricExecutor, AverageMaterialByPlayerAtMoveExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/AnalyticsQuery.cs
+++ b/src/Interfaces/Analytics/AnalyticsQuery.cs
@@ -24,6 +24,24 @@ public sealed class AnalyticsQuery
     /// <summary>Exact match on <c>dbo.Game.Eco</c> when set.</summary>
     public string? Eco { get; init; }
 
+    /// <summary>Primary player for player-comparison metrics.</summary>
+    public string? PlayerASurname { get; init; }
+
+    /// <summary>Primary player's forenames. Empty string matches players with no forenames.</summary>
+    public string? PlayerAForenames { get; init; }
+
+    /// <summary>Optional comparison player for player-comparison metrics. When omitted, metrics may compare against all players.</summary>
+    public string? PlayerBSurname { get; init; }
+
+    /// <summary>Comparison player's forenames. Empty string matches players with no forenames.</summary>
+    public string? PlayerBForenames { get; init; }
+
+    /// <summary>Colour mode for player-comparison metrics: <c>Any</c>, <c>White</c>, or <c>Black</c>.</summary>
+    public string? PlayerColour { get; init; }
+
+    /// <summary>User-facing full move number. For position summaries, full move N maps to ply <c>(N * 2) - 1</c>.</summary>
+    public int? MoveNumber { get; init; }
+
     /// <summary>
     /// Board snapshot ply for average-material metric (must exist in <c>GamePositionSummary</c>).
     /// When null, the executor uses ply <c>4</c> (PLAN §5.3.4).

--- a/src/Interfaces/Analytics/PlayerMaterialAverageRow.cs
+++ b/src/Interfaces/Analytics/PlayerMaterialAverageRow.cs
@@ -1,0 +1,20 @@
+namespace Interfaces.Analytics;
+
+public sealed class PlayerMaterialAverageRow
+{
+    public string Series { get; init; } = string.Empty;
+
+    public string? PlayerSurname { get; init; }
+
+    public string? PlayerForenames { get; init; }
+
+    public string Colour { get; init; } = string.Empty;
+
+    public int MoveNumber { get; init; }
+
+    public int PlyIndex { get; init; }
+
+    public double AvgMaterial { get; init; }
+
+    public int PositionCount { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -87,6 +87,16 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Average material for Player A compared with Player B or all players at one ply.
+        /// </summary>
+        Task<IReadOnlyList<PlayerMaterialAverageRow>> GetPlayerMaterialAveragesAtPlyAsync(
+            AnalyticsQuery query,
+            int moveNumber,
+            int plyIndex,
+            string colourMode,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -584,6 +594,37 @@ namespace Repositories
                         WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
                         BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
                         BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerMaterialAverageRow>> GetPlayerMaterialAveragesAtPlyAsync(
+            AnalyticsQuery query,
+            int moveNumber,
+            int plyIndex,
+            string colourMode,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerMaterialAverageRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPlayerMaterialAveragesAtPly,
+                    new
+                    {
+                        MoveNumber = moveNumber,
+                        PlyIndex = plyIndex,
+                        ColourMode = colourMode,
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerASurname = NormalizeNonEmpty(query.PlayerASurname),
+                        PlayerAForenames = NormalizeNamePart(query.PlayerAForenames),
+                        PlayerBSurname = NormalizeNonEmpty(query.PlayerBSurname),
+                        PlayerBForenames = NormalizeNamePart(query.PlayerBForenames),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -162,6 +162,82 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Player A average material at a ply compared with Player B, or all players when Player B is omitted.
+        /// ColourMode is one of Any, White, Black.
+        /// </summary>
+        public static string GetPlayerMaterialAveragesAtPly =>
+            """
+            WITH Appearance AS
+            (
+                SELECT p.Surname,
+                       p.Forenames,
+                       CAST('White' AS NVARCHAR(8)) AS Colour,
+                       s.WhiteMaterial AS Material
+                FROM dbo.Game g
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = g.Id AND s.PlyIndex = @PlyIndex
+                INNER JOIN dbo.Player p ON p.Id = g.WhitePlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+
+                UNION ALL
+
+                SELECT p.Surname,
+                       p.Forenames,
+                       CAST('Black' AS NVARCHAR(8)) AS Colour,
+                       s.BlackMaterial AS Material
+                FROM dbo.Game g
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = g.Id AND s.PlyIndex = @PlyIndex
+                INNER JOIN dbo.Player p ON p.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            )
+            SELECT Series,
+                   PlayerSurname,
+                   PlayerForenames,
+                   Colour,
+                   MoveNumber,
+                   PlyIndex,
+                   AvgMaterial,
+                   PositionCount
+            FROM
+            (
+                SELECT 1 AS SortOrder,
+                       CAST('PlayerA' AS NVARCHAR(16)) AS Series,
+                       @PlayerASurname AS PlayerSurname,
+                       @PlayerAForenames AS PlayerForenames,
+                       @ColourMode AS Colour,
+                       @MoveNumber AS MoveNumber,
+                       @PlyIndex AS PlyIndex,
+                       AVG(CAST(Material AS FLOAT)) AS AvgMaterial,
+                       COUNT(*) AS PositionCount
+                FROM Appearance
+                WHERE Surname = @PlayerASurname
+                  AND (@PlayerAForenames IS NULL OR Forenames = @PlayerAForenames)
+                  AND (@ColourMode = 'Any' OR Colour = @ColourMode)
+                HAVING COUNT(*) > 0
+
+                UNION ALL
+
+                SELECT 2 AS SortOrder,
+                       CASE WHEN @PlayerBSurname IS NULL THEN CAST('AllPlayers' AS NVARCHAR(16)) ELSE CAST('PlayerB' AS NVARCHAR(16)) END AS Series,
+                       @PlayerBSurname AS PlayerSurname,
+                       @PlayerBForenames AS PlayerForenames,
+                       @ColourMode AS Colour,
+                       @MoveNumber AS MoveNumber,
+                       @PlyIndex AS PlyIndex,
+                       AVG(CAST(Material AS FLOAT)) AS AvgMaterial,
+                       COUNT(*) AS PositionCount
+                FROM Appearance
+                WHERE (@PlayerBSurname IS NULL OR (Surname = @PlayerBSurname AND (@PlayerBForenames IS NULL OR Forenames = @PlayerBForenames)))
+                  AND (@ColourMode = 'Any' OR Colour = @ColourMode)
+                HAVING COUNT(*) > 0
+            ) x
+            ORDER BY SortOrder;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/AverageMaterialByPlayerAtMoveExecutor.cs
+++ b/src/Services/Analytics/AverageMaterialByPlayerAtMoveExecutor.cs
@@ -1,0 +1,88 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Compares one player's average material at a full move against another player or all players.
+/// </summary>
+public sealed class AverageMaterialByPlayerAtMoveExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private const int DefaultMoveNumber = 1;
+    private const string DefaultColourMode = "Any";
+
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "AverageMaterialByPlayerAtMove";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (string.IsNullOrWhiteSpace(query.PlayerASurname))
+            throw new ArgumentException("playerASurname is required for AverageMaterialByPlayerAtMove.", nameof(query));
+
+        var moveNumber = query.MoveNumber ?? DefaultMoveNumber;
+        var plyIndex = MoveNumberToPlyIndex(moveNumber);
+        var colourMode = NormalizeColourMode(query.PlayerColour);
+
+        var rows = await _repository
+            .GetPlayerMaterialAveragesAtPlyAsync(query, moveNumber, plyIndex, colourMode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!rows.Any(r => string.Equals(r.Series, "PlayerA", StringComparison.OrdinalIgnoreCase)))
+            return AnalyticsTableResult.Empty("Series", "Player", "Colour", "MoveNumber", "PlyIndex", "AvgMaterial", "PositionCount");
+
+        IReadOnlyList<object?> Row(PlayerMaterialAverageRow r) =>
+            new object?[]
+            {
+                r.Series,
+                FormatPlayer(r.PlayerSurname, r.PlayerForenames),
+                r.Colour,
+                r.MoveNumber,
+                r.PlyIndex,
+                r.AvgMaterial,
+                r.PositionCount
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Series", "Player", "Colour", "MoveNumber", "PlyIndex", "AvgMaterial", "PositionCount"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    public static int MoveNumberToPlyIndex(int moveNumber)
+    {
+        if (moveNumber < 1)
+            throw new ArgumentOutOfRangeException(nameof(moveNumber), "moveNumber must be >= 1.");
+
+        return (moveNumber * 2) - 1;
+    }
+
+    public static string NormalizeColourMode(string? colour)
+    {
+        if (string.IsNullOrWhiteSpace(colour))
+            return DefaultColourMode;
+
+        var trimmed = colour.Trim();
+        if (string.Equals(trimmed, "Any", StringComparison.OrdinalIgnoreCase))
+            return "Any";
+        if (string.Equals(trimmed, "White", StringComparison.OrdinalIgnoreCase))
+            return "White";
+        if (string.Equals(trimmed, "Black", StringComparison.OrdinalIgnoreCase))
+            return "Black";
+
+        throw new ArgumentException("playerColour must be Any, White, or Black.", nameof(colour));
+    }
+
+    private static string FormatPlayer(string? surname, string? forenames)
+    {
+        if (string.IsNullOrWhiteSpace(surname))
+            return "All players";
+
+        var s = surname.Trim();
+        var f = forenames?.Trim() ?? string.Empty;
+        return f.Length == 0 ? s : $"{s}, {f}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -54,6 +54,13 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<GameCountByEcoRow>>();
 
+    public Task<IReadOnlyList<PlayerMaterialAverageRow>> GetPlayerMaterialAveragesAtPlyAsync(
+        AnalyticsQuery query,
+        int moveNumber,
+        int plyIndex,
+        string colourMode,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerMaterialAverageRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/AnalyserTests/AnalyticsMetricsControllerTests.cs
+++ b/test/AnalyserTests/AnalyticsMetricsControllerTests.cs
@@ -39,6 +39,22 @@ public class AnalyticsMetricsControllerTests
     }
 
     [Fact]
+    public async Task Execute_InvalidMetricArguments_Returns400()
+    {
+        var registry = new Mock<IMetricRegistry>();
+        registry.Setup(r => r.ExecuteAsync("AverageMaterialByPlayerAtMove", It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("playerASurname is required."));
+
+        var sut = new AnalyticsMetricsController(registry.Object);
+        var result = await sut.Execute(
+            new ExecuteMetricRequest { MetricKey = "AverageMaterialByPlayerAtMove", Query = new AnalyticsQuery() },
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("playerASurname is required.", badRequest.Value);
+    }
+
+    [Fact]
     public async Task Execute_ValidMetric_ReturnsTable()
     {
         var table = new AnalyticsTableResult

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -17,18 +17,27 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<KnightDestinationCountRow>());
         repo.Setup(r => r.GetGameCountsByEcoAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<GameCountByEcoRow>());
+        repo.Setup(r => r.GetPlayerMaterialAveragesAtPlyAsync(
+                It.IsAny<AnalyticsQuery>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerMaterialAverageRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
             new AverageMaterialByYearAndColourExecutor(repo.Object),
             new KnightMoveDestinationFrequencyExecutor(repo.Object),
-            new GameCountByEcoExecutor(repo.Object)
+            new GameCountByEcoExecutor(repo.Object),
+            new AverageMaterialByPlayerAtMoveExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
         Assert.Contains("KnightMoveDestinationFrequency", sut.MetricKeys);
         Assert.Contains("GameCountByEco", sut.MetricKeys);
-        Assert.Equal(3, sut.MetricKeys.Count);
+        Assert.Contains("AverageMaterialByPlayerAtMove", sut.MetricKeys);
+        Assert.Equal(4, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -177,5 +186,138 @@ public class MetricRegistryAndExecutorsTests
                 && q.WhitePlayerForenames == "Garry"
                 && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 3)]
+    [InlineData(10, 19)]
+    public void AverageMaterialByPlayerAtMoveExecutor_MapsMoveNumberToFullMovePly(int moveNumber, int expectedPly)
+    {
+        Assert.Equal(expectedPly, AverageMaterialByPlayerAtMoveExecutor.MoveNumberToPlyIndex(moveNumber));
+    }
+
+    [Fact]
+    public void AverageMaterialByPlayerAtMoveExecutor_RejectsMoveNumberLessThanOne()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AverageMaterialByPlayerAtMoveExecutor.MoveNumberToPlyIndex(0));
+    }
+
+    [Theory]
+    [InlineData(null, "Any")]
+    [InlineData("any", "Any")]
+    [InlineData("WHITE", "White")]
+    [InlineData("black", "Black")]
+    public void AverageMaterialByPlayerAtMoveExecutor_NormalizesColourMode(string? input, string expected)
+    {
+        Assert.Equal(expected, AverageMaterialByPlayerAtMoveExecutor.NormalizeColourMode(input));
+    }
+
+    [Fact]
+    public async Task AverageMaterialByPlayerAtMoveExecutor_PlayerAComparedWithAllPlayers_MapsRows()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetPlayerMaterialAveragesAtPlyAsync(
+                It.IsAny<AnalyticsQuery>(),
+                2,
+                3,
+                "Any",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerMaterialAverageRow>
+            {
+                new() { Series = "PlayerA", PlayerSurname = "Kasparov", PlayerForenames = "Garry", Colour = "Any", MoveNumber = 2, PlyIndex = 3, AvgMaterial = 38.5, PositionCount = 10 },
+                new() { Series = "AllPlayers", PlayerSurname = null, PlayerForenames = null, Colour = "Any", MoveNumber = 2, PlyIndex = 3, AvgMaterial = 39.1, PositionCount = 200 }
+            });
+
+        var sut = new AverageMaterialByPlayerAtMoveExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerASurname = "Kasparov",
+            PlayerAForenames = "Garry",
+            MoveNumber = 2
+        });
+
+        Assert.Equal(["Series", "Player", "Colour", "MoveNumber", "PlyIndex", "AvgMaterial", "PositionCount"], result.ColumnNames);
+        Assert.Equal(2, result.Rows.Count);
+        Assert.Equal("PlayerA", result.Rows[0][0]);
+        Assert.Equal("Kasparov, Garry", result.Rows[0][1]);
+        Assert.Equal(38.5, result.Rows[0][5]);
+        Assert.Equal("All players", result.Rows[1][1]);
+    }
+
+    [Fact]
+    public async Task AverageMaterialByPlayerAtMoveExecutor_PlayerAComparedWithPlayerB_PassesQueryToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetPlayerMaterialAveragesAtPlyAsync(
+                It.IsAny<AnalyticsQuery>(),
+                3,
+                5,
+                "White",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerMaterialAverageRow>
+            {
+                new() { Series = "PlayerA", PlayerSurname = "Kasparov", PlayerForenames = "Garry", Colour = "White", MoveNumber = 3, PlyIndex = 5, AvgMaterial = 38, PositionCount = 1 },
+                new() { Series = "PlayerB", PlayerSurname = "Karpov", PlayerForenames = "Anatoly", Colour = "White", MoveNumber = 3, PlyIndex = 5, AvgMaterial = 39, PositionCount = 1 }
+            });
+
+        var query = new AnalyticsQuery
+        {
+            PlayerASurname = "Kasparov",
+            PlayerAForenames = "Garry",
+            PlayerBSurname = "Karpov",
+            PlayerBForenames = "Anatoly",
+            PlayerColour = "White",
+            MoveNumber = 3,
+            MinGameYear = 1980,
+            Eco = "B90"
+        };
+        var sut = new AverageMaterialByPlayerAtMoveExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetPlayerMaterialAveragesAtPlyAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerASurname == "Kasparov"
+                && q.PlayerAForenames == "Garry"
+                && q.PlayerBSurname == "Karpov"
+                && q.PlayerBForenames == "Anatoly"
+                && q.MinGameYear == 1980
+                && q.Eco == "B90"),
+            3,
+            5,
+            "White",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AverageMaterialByPlayerAtMoveExecutor_ReturnsEmpty_WhenPlayerAHasNoRows()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetPlayerMaterialAveragesAtPlyAsync(
+                It.IsAny<AnalyticsQuery>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerMaterialAverageRow>
+            {
+                new() { Series = "AllPlayers", Colour = "Any", MoveNumber = 1, PlyIndex = 1, AvgMaterial = 39, PositionCount = 10 }
+            });
+
+        var sut = new AverageMaterialByPlayerAtMoveExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery { PlayerASurname = "NoSuchPlayer" });
+
+        Assert.Empty(result.Rows);
+    }
+
+    [Fact]
+    public async Task AverageMaterialByPlayerAtMoveExecutor_RequiresPlayerASurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new AverageMaterialByPlayerAtMoveExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
     }
 }


### PR DESCRIPTION
## Summary

Adds `AverageMaterialByPlayerAtMove`, a new analytics metric for comparing one player's average material at a full move against another player or against the all-player baseline. This completes PLAN §12.5 item 2 and keeps the existing side-material-by-year metric separate from true player comparison semantics.

## Changes

- Added `AverageMaterialByPlayerAtMoveExecutor`.
- Added `PlayerMaterialAverageRow` result DTO.
- Extended `AnalyticsQuery` with player-comparison fields:
  - `playerASurname` / `playerAForenames`
  - optional `playerBSurname` / `playerBForenames`
  - `playerColour` (`Any`, `White`, `Black`)
  - `moveNumber`
- Added repository contract and SQL for player material averages at a mapped ply.
- Implemented move number mapping: full move `N` -> `PlyIndex = (N * 2) - 1`.
- Registered the new metric in DI and `MetricCatalog`.
- Updated `AnalyticsMetricsController` to return `400` for invalid metric arguments.
- Added executor and controller tests for mapping, colour modes, Player A vs Player B, Player A vs all players, empty Player A results, and bad metric arguments.
- Updated `EXAMPLE_ANALYSES.md` with a runnable HTTP example.
- Marked PLAN §12.5 item 2 complete.

## How to test

- `dotnet build src/Analyser/Analyser.csproj`
- `dotnet test test/ServicesTests/ServicesTests.csproj`
- `dotnet test test/AnalyserTests/ControllerTests.csproj`

## Notes

This PR does not add metric-specific UI fields yet. That remains PLAN §12.5 item 3. Until then, run `AverageMaterialByPlayerAtMove` through Swagger or another HTTP client.