### PR TITLE
feat: add metric discovery parameter hints.

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-05-10 (PLAN **§12.4** item 1: **unified `wwwroot` web UI** next; then metrics extension; HTTP auth **deferred** — see [PLAN.md §12.4](./PLAN.md).)
+**Last updated:** 2026-05-11 (PLAN **§12.4** item 3: metrics discovery hints added; HTTP auth **deferred** — see [PLAN.md §12.4](./PLAN.md).)
 
 ---
 
@@ -24,15 +24,15 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 - **Done:** PGN parse → player resolution → bitboard positions per ply → persist **`Game`**, **`BoardPosition`**, **`Player`**, parse errors. GitHub Actions runs **`dotnet test`** on PRs.
 - **Housekeeping added:** schema-history scaffolding (`src/Migrations/History/` + `tools/export-db-history.ps1`) to snapshot current SQL object DDL after migrations.
-- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4). **Next product slice:** single **`wwwroot`** web experience for ETL + metrics + game browse (PLAN §12.4 item 1); then more metrics / catalog.
+- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, and metrics discovery descriptions plus parameter hints. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
 
 ---
 
 ## 3. Recommended next step (small slice)
 
-**Do next:** **[PLAN.md §12.4](./PLAN.md) item 1 — unified `wwwroot` web UI:** extend **`src/Analyser/wwwroot`** (e.g. `index.html` or a small multi-section layout) so **all routine workflows** run in the browser: ETL path + load + progress + cancel (already started), plus **metrics** (discovery + execute against existing APIs) and **paged games** (`GetGames` with query params). Treat Swagger as optional “API docs” via a link, not the default path.
+**Do next:** **[PLAN.md §12.4](./PLAN.md) item 2 — extend the metrics surface:** add another small **`IMetricExecutor`** for a concrete analysis question, following the existing repository-read + `AnalyticsTableResult` pattern. Keep inputs explicit in `AnalyticsQuery`, register the executor in DI, and add parameter hints in `MetricCatalog`.
 
-**Then:** §12.4 items 2–4 (more **`IMetricExecutor`**s, richer discovery text, tests). Optionally refresh [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) if deriver/summary hot paths change.
+**Then:** Continue §12.4 item 4 tests as needed for each new metric. Optionally refresh [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) if deriver/summary hot paths change.
 
 **Do not prioritize yet:** Dedicated HTTP **auth / rate limits** for `AnalyticsMetricsController` — **out of scope** until there is a **deployment or network exposure** plan (then treat as blocking; update PLAN §12.1 / §13). Optional hygiene: bind the dev host to **localhost** only.
 

--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -97,6 +97,9 @@ Discover metrics from the web UI or by calling:
 GET /api/analytics/metrics
 ```
 
+Discovery returns each metric key, a short description, and parameter hints for the most relevant
+query fields. The web UI shows those hints under **Refresh metric list**.
+
 Current metric keys:
 
 - `AverageMaterialByYearAndColour`

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -294,7 +294,7 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 
 1. **Unified local web UI (`wwwroot`)** — make the static app the **primary** surface for solo use: PGN path, **LoadGames**, progress polling, **CancelLoad** (already partly on `index.html`); add sections that call existing JSON APIs for **metrics discovery + execute** (`GET/POST /api/analytics/metrics/…`) and **paged GetGames** (`GET /Analyser/GetGames` with filters) so routine work does not require Swagger. Keep **Swagger** as an optional dev “API docs” link, not part of the default workflow.
 2. **Extend the metrics surface** — add **`IMetricExecutor`** implementations for additional questions you care about (same patterns as the two reference metrics: parameterized repository reads, tabular `AnalyticsTableResult` only). Register them in **`IMetricRegistry`** / DI.
-3. **Improve discovery** — enrich **`GET /api/analytics/metrics`** with clearer descriptions (and optional parameter hints) so the web UI and Swagger stay usable as the catalog grows.
+3. [x] **Improve discovery** — enrich **`GET /api/analytics/metrics`** with clearer descriptions and parameter hints so the web UI and Swagger stay usable as the catalog grows.
 4. **Tests** — per-metric executor tests with mocked **`IChessRepository`** (and API smoke tests for new keys), following §12.3; add light **Playwright** or manual test notes for the unified web UI if you introduce non-trivial client script.
 
 **Optional:** Record a fresh materialization throughput line in [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) when you change hot paths in the deriver or summary factory.

--- a/src/Analyser/Controllers/AnalyticsMetricsController.cs
+++ b/src/Analyser/Controllers/AnalyticsMetricsController.cs
@@ -26,7 +26,8 @@ public sealed class AnalyticsMetricsController(IMetricRegistry metricRegistry) :
             .Select(k => new MetricDescriptorResponse
             {
                 MetricKey = k,
-                Description = MetricCatalog.TryGetDescription(k)
+                Description = MetricCatalog.TryGetDescription(k),
+                ParameterHints = MetricCatalog.GetParameterHints(k)
             })
             .ToList();
 

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -23,4 +23,41 @@ internal static class MetricCatalog
             _ => null
         };
     }
+
+    public static IReadOnlyList<string> GetParameterHints(string metricKey)
+    {
+        if (string.IsNullOrEmpty(metricKey))
+            return [];
+
+        return metricKey.Trim() switch
+        {
+            "AverageMaterialByYearAndColour" =>
+            [
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: summaryPlyIndex (defaults to 4).",
+                "Do not use for independent player-vs-player comparisons."
+            ],
+            "KnightMoveDestinationFrequency" =>
+            [
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
+                "Returns numeric ToSquare values (0-63)."
+            ],
+            "GameCountByEco" =>
+            [
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
+                "Rows with blank or missing ECO are excluded."
+            ],
+            "AverageMaterialByPlayerAtMove" =>
+            [
+                "Required: playerASurname (playerAForenames optional but recommended).",
+                "Optional: playerBSurname/playerBForenames; omit Player B for all-player baseline.",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: moveNumber (defaults to 1; full move N maps to PlyIndex = N * 2 - 1).",
+                "Optional: minGameYear, maxGameYear, eco."
+            ],
+            _ => []
+        };
+    }
 }

--- a/src/Analyser/Models/MetricDescriptorResponse.cs
+++ b/src/Analyser/Models/MetricDescriptorResponse.cs
@@ -9,4 +9,7 @@ public sealed class MetricDescriptorResponse
 
     /// <summary>Human-readable summary when known to the host catalog.</summary>
     public string? Description { get; init; }
+
+    /// <summary>Short hints for the most relevant query parameters for this metric.</summary>
+    public required IReadOnlyList<string> ParameterHints { get; init; }
 }

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -467,8 +467,15 @@
             }
             metricList.innerHTML = '<ul style="margin:0.25rem 0;padding-left:1.2rem;">' +
               list.map(function (m) {
+                var hints = (m.parameterHints && m.parameterHints.length)
+                  ? '<ul style="margin:0.2rem 0 0.45rem 1rem;padding-left:1rem;">' +
+                    m.parameterHints.map(function (h) { return '<li>' + escapeHtml(h) + '</li>'; }).join('') +
+                    '</ul>'
+                  : '';
                 return '<li><strong>' + escapeHtml(m.metricKey) + '</strong>' +
-                  (m.description ? ' — ' + escapeHtml(m.description) : '') + '</li>';
+                  (m.description ? ' — ' + escapeHtml(m.description) : '') +
+                  hints +
+                  '</li>';
               }).join('') + '</ul>';
             list.forEach(function (m) {
               var opt = document.createElement('option');

--- a/test/AnalyserTests/AnalyticsMetricsControllerTests.cs
+++ b/test/AnalyserTests/AnalyticsMetricsControllerTests.cs
@@ -23,6 +23,8 @@ public class AnalyticsMetricsControllerTests
         Assert.Equal("AverageMaterialByYearAndColour", list[0].MetricKey);
         Assert.Equal("KnightMoveDestinationFrequency", list[1].MetricKey);
         Assert.False(string.IsNullOrEmpty(list[0].Description));
+        Assert.NotEmpty(list[0].ParameterHints);
+        Assert.Contains(list[0].ParameterHints, h => h.Contains("summaryPlyIndex", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Improve analytics metric discovery by returning parameter hints from the metrics catalog and showing them in the local web UI. This makes each metric easier to run without relying on prior knowledge of `AnalyticsQuery`.

## Changes

- Add `parameterHints` to metric discovery responses.
- Add catalog hints for each registered metric.
- Render metric hints in `wwwroot/index.html`.
- Update controller tests and docs/plan handoff notes.

## How to test

- `dotnet test "test\AnalyserTests\ControllerTests.csproj" --no-restore -p:BaseOutputPath="obj\cursor-test\"`
- `dotnet test "ChessAnalyser.sln" --no-restore -p:BaseOutputPath="obj\cursor-test\"`

## Notes

The full test suite passes. Existing unrelated compiler/analyzer warnings remain in test projects.