### PR TITLE
feat: add game count by year metric.

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-05-11 (PLAN **§12.4** item 3: metrics discovery hints added; HTTP auth **deferred** — see [PLAN.md §12.4](./PLAN.md).)
+**Last updated:** 2026-05-11 (PLAN **§12.4** item 2: `GameCountByYear` metric added; HTTP auth **deferred** — see [PLAN.md §12.4](./PLAN.md).)
 
 ---
 
@@ -24,13 +24,13 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 - **Done:** PGN parse → player resolution → bitboard positions per ply → persist **`Game`**, **`BoardPosition`**, **`Player`**, parse errors. GitHub Actions runs **`dotnet test`** on PRs.
 - **Housekeeping added:** schema-history scaffolding (`src/Migrations/History/` + `tools/export-db-history.ps1`) to snapshot current SQL object DDL after migrations.
-- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, and metrics discovery descriptions plus parameter hints. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
+- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, and metrics discovery descriptions plus parameter hints. **Done (metrics surface):** `GameCountByEco`, `AverageMaterialByPlayerAtMove`, and `GameCountByYear`. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
 
 ---
 
 ## 3. Recommended next step (small slice)
 
-**Do next:** **[PLAN.md §12.4](./PLAN.md) item 2 — extend the metrics surface:** add another small **`IMetricExecutor`** for a concrete analysis question, following the existing repository-read + `AnalyticsTableResult` pattern. Keep inputs explicit in `AnalyticsQuery`, register the executor in DI, and add parameter hints in `MetricCatalog`.
+**Do next:** No fixed planned PR is queued. Choose the next concrete analysis question before adding another metric, or do a small cleanup/test-hardening slice if one is called out by the maintainer.
 
 **Then:** Continue §12.4 item 4 tests as needed for each new metric. Optionally refresh [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) if deriver/summary hot paths change.
 

--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -105,6 +105,7 @@ Current metric keys:
 - `AverageMaterialByYearAndColour`
 - `KnightMoveDestinationFrequency`
 - `GameCountByEco`
+- `GameCountByYear`
 - `AverageMaterialByPlayerAtMove`
 
 Metrics support the shared `AnalyticsQuery` filter shape where the filter is meaningful for that
@@ -371,7 +372,56 @@ Content-Type: application/json
 
 ---
 
-## 8. Example analysis: browse the game population
+## 8. Example analysis: game count by year
+
+### Question
+
+How are the loaded games distributed over calendar years?
+
+### Why it is useful
+
+This is a fast corpus-shape metric for checking whether the loaded PGNs cover the expected years
+and whether `GameYear` parsing looks sensible before running deeper year-based analyses.
+
+### Run it in the UI
+
+In **Analytics metrics**:
+
+- Metric key: `GameCountByYear`
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+
+Click **Run metric**.
+
+### Equivalent HTTP request
+
+```http
+POST /api/analytics/metrics/execute
+Content-Type: application/json
+```
+
+```json
+{
+  "metricKey": "GameCountByYear",
+  "query": {
+    "minGameYear": 1900,
+    "maxGameYear": 1950
+  }
+}
+```
+
+### Result columns
+
+- `GameYear`
+- `GameCount`
+
+### Notes
+
+- Games with `GameYear = NULL` are excluded.
+- Supplying `eco` narrows the year distribution to games with that exact ECO code.
+
+---
+
+## 9. Example analysis: browse the game population
 
 ### Question
 
@@ -401,7 +451,7 @@ GET /Analyser/GetGames?page=1&pageSize=50&minGameYear=1900&maxGameYear=1950
 
 ---
 
-## 9. Useful SQL checks
+## 10. Useful SQL checks
 
 Use these as diagnostics, not as the primary application surface.
 
@@ -444,7 +494,7 @@ ORDER BY g.Id;
 
 ---
 
-## 10. Adding a new example analysis to this document
+## 11. Adding a new example analysis to this document
 
 Use this template:
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -293,7 +293,7 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 **Suggested next work (PR-sized, in order of value):**
 
 1. **Unified local web UI (`wwwroot`)** — make the static app the **primary** surface for solo use: PGN path, **LoadGames**, progress polling, **CancelLoad** (already partly on `index.html`); add sections that call existing JSON APIs for **metrics discovery + execute** (`GET/POST /api/analytics/metrics/…`) and **paged GetGames** (`GET /Analyser/GetGames` with filters) so routine work does not require Swagger. Keep **Swagger** as an optional dev “API docs” link, not part of the default workflow.
-2. **Extend the metrics surface** — add **`IMetricExecutor`** implementations for additional questions you care about (same patterns as the two reference metrics: parameterized repository reads, tabular `AnalyticsTableResult` only). Register them in **`IMetricRegistry`** / DI.
+2. [x] **Extend the metrics surface** — add **`IMetricExecutor`** implementations for additional questions you care about (same patterns as the two reference metrics: parameterized repository reads, tabular `AnalyticsTableResult` only). Register them in **`IMetricRegistry`** / DI. Current additions include `GameCountByEco`, `AverageMaterialByPlayerAtMove`, and `GameCountByYear`.
 3. [x] **Improve discovery** — enrich **`GET /api/analytics/metrics`** with clearer descriptions and parameter hints so the web UI and Swagger stay usable as the catalog grows.
 4. **Tests** — per-metric executor tests with mocked **`IChessRepository`** (and API smoke tests for new keys), following §12.3; add light **Playwright** or manual test notes for the unified web UI if you introduce non-trivial client script.
 

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -18,6 +18,8 @@ internal static class MetricCatalog
                 "Count of knight half-moves grouped by destination square (ToSquare), with optional Game filters.",
             "GameCountByEco" =>
                 "Count of games grouped by ECO code, with optional year, player-name, and ECO filters.",
+            "GameCountByYear" =>
+                "Count of games grouped by parsed GameYear, with optional player-name and ECO filters.",
             "AverageMaterialByPlayerAtMove" =>
                 "Average material at a full move for Player A compared with Player B, or all players, with colour mode Any/White/Black.",
             _ => null
@@ -48,6 +50,12 @@ internal static class MetricCatalog
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
                 "Rows with blank or missing ECO are excluded."
+            ],
+            "GameCountByYear" =>
+            [
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
+                "Rows without a parsed GameYear are excluded."
             ],
             "AverageMaterialByPlayerAtMove" =>
             [

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -85,6 +85,7 @@ builder.Services.AddScoped<IAnalyticsMaterializationService, AnalyticsMaterializ
 builder.Services.AddScoped<IMetricExecutor, AverageMaterialByYearAndColourExecutor>();
 builder.Services.AddScoped<IMetricExecutor, KnightMoveDestinationFrequencyExecutor>();
 builder.Services.AddScoped<IMetricExecutor, GameCountByEcoExecutor>();
+builder.Services.AddScoped<IMetricExecutor, GameCountByYearExecutor>();
 builder.Services.AddScoped<IMetricExecutor, AverageMaterialByPlayerAtMoveExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();

--- a/src/Interfaces/Analytics/GameCountByYearRow.cs
+++ b/src/Interfaces/Analytics/GameCountByYearRow.cs
@@ -1,0 +1,8 @@
+namespace Interfaces.Analytics;
+
+public sealed class GameCountByYearRow
+{
+    public short GameYear { get; init; }
+
+    public int GameCount { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -87,6 +87,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Counts games by <c>GameYear</c> with optional game filters.
+        /// </summary>
+        Task<IReadOnlyList<GameCountByYearRow>> GetGameCountsByYearAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Average material for Player A compared with Player B or all players at one ply.
         /// </summary>
         Task<IReadOnlyList<PlayerMaterialAverageRow>> GetPlayerMaterialAveragesAtPlyAsync(
@@ -586,6 +593,31 @@ namespace Repositories
             var rows = (await connection.QueryAsync<GameCountByEcoRow>(
                 new CommandDefinition(
                     SqlStatements.GetGameCountsByEco,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
+                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
+                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
+                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<GameCountByYearRow>> GetGameCountsByYearAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<GameCountByYearRow>(
+                new CommandDefinition(
+                    SqlStatements.GetGameCountsByYear,
                     new
                     {
                         MinGameYear = query.MinGameYear,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -162,6 +162,25 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Games grouped by calendar year; games without a parsed year are excluded.
+        /// </summary>
+        public static string GetGameCountsByYear =>
+            """
+            SELECT g.GameYear AS GameYear, COUNT(*) AS GameCount
+            FROM dbo.Game g
+            LEFT JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+            LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+            WHERE g.GameYear IS NOT NULL
+              AND (@MinGameYear IS NULL OR g.GameYear >= @MinGameYear)
+              AND (@MaxGameYear IS NULL OR g.GameYear <= @MaxGameYear)
+              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
+              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+              AND (@Eco IS NULL OR g.Eco = @Eco)
+            GROUP BY g.GameYear
+            ORDER BY g.GameYear;
+            """;
+
+        /// <summary>
         /// Player A average material at a ply compared with Player B, or all players when Player B is omitted.
         /// ColourMode is one of Any, White, Black.
         /// </summary>

--- a/src/Services/Analytics/GameCountByYearExecutor.cs
+++ b/src/Services/Analytics/GameCountByYearExecutor.cs
@@ -1,0 +1,29 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Counts games by parsed calendar year with the shared game filters.
+/// </summary>
+public sealed class GameCountByYearExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "GameCountByYear";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var rows = await _repository.GetGameCountsByYearAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(GameCountByYearRow r) =>
+            new object?[] { r.GameYear, r.GameCount };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["GameYear", "GameCount"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -54,6 +54,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<GameCountByEcoRow>>();
 
+    public Task<IReadOnlyList<GameCountByYearRow>> GetGameCountsByYearAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<GameCountByYearRow>>();
+
     public Task<IReadOnlyList<PlayerMaterialAverageRow>> GetPlayerMaterialAveragesAtPlyAsync(
         AnalyticsQuery query,
         int moveNumber,

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -8,7 +8,7 @@ namespace ServicesTests.Analytics;
 public class MetricRegistryAndExecutorsTests
 {
     [Fact]
-    public void MetricRegistry_ContainsBothReferenceMetricKeys()
+    public void MetricRegistry_ContainsRegisteredMetricKeys()
     {
         var repo = new Mock<IChessRepository>();
         repo.Setup(r => r.GetMaterialAveragesByYearAtPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -17,6 +17,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<KnightDestinationCountRow>());
         repo.Setup(r => r.GetGameCountsByEcoAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<GameCountByEcoRow>());
+        repo.Setup(r => r.GetGameCountsByYearAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<GameCountByYearRow>());
         repo.Setup(r => r.GetPlayerMaterialAveragesAtPlyAsync(
                 It.IsAny<AnalyticsQuery>(),
                 It.IsAny<int>(),
@@ -30,14 +32,16 @@ public class MetricRegistryAndExecutorsTests
             new AverageMaterialByYearAndColourExecutor(repo.Object),
             new KnightMoveDestinationFrequencyExecutor(repo.Object),
             new GameCountByEcoExecutor(repo.Object),
+            new GameCountByYearExecutor(repo.Object),
             new AverageMaterialByPlayerAtMoveExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
         Assert.Contains("KnightMoveDestinationFrequency", sut.MetricKeys);
         Assert.Contains("GameCountByEco", sut.MetricKeys);
+        Assert.Contains("GameCountByYear", sut.MetricKeys);
         Assert.Contains("AverageMaterialByPlayerAtMove", sut.MetricKeys);
-        Assert.Equal(4, sut.MetricKeys.Count);
+        Assert.Equal(5, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -184,6 +188,55 @@ public class MetricRegistryAndExecutorsTests
                 q.MinGameYear == 1980
                 && q.WhitePlayerSurname == "Kasparov"
                 && q.WhitePlayerForenames == "Garry"
+                && q.Eco == "B90"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GameCountByYearExecutor_MapsRows()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetGameCountsByYearAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GameCountByYearRow>
+            {
+                new() { GameYear = 1985, GameCount = 12 },
+                new() { GameYear = 1986, GameCount = 5 }
+            });
+
+        var sut = new GameCountByYearExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery());
+
+        Assert.Equal(["GameYear", "GameCount"], result.ColumnNames);
+        Assert.Equal(2, result.Rows.Count);
+        Assert.Equal((short)1985, result.Rows[0][0]);
+        Assert.Equal(12, result.Rows[0][1]);
+    }
+
+    [Fact]
+    public async Task GameCountByYearExecutor_PassesNameFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetGameCountsByYearAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<GameCountByYearRow>());
+
+        var query = new AnalyticsQuery
+        {
+            MinGameYear = 1980,
+            MaxGameYear = 1990,
+            BlackPlayerSurname = "Karpov",
+            BlackPlayerForenames = "Anatoly",
+            Eco = "B90"
+        };
+        var sut = new GameCountByYearExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetGameCountsByYearAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.MinGameYear == 1980
+                && q.MaxGameYear == 1990
+                && q.BlackPlayerSurname == "Karpov"
+                && q.BlackPlayerForenames == "Anatoly"
                 && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
     }


### PR DESCRIPTION
## Summary

Add a `GameCountByYear` analytics metric so the UI/API can show how loaded games are distributed across parsed calendar years. This gives a quick corpus-shape check before running deeper year-based analyses.

## Changes

- Add `GameCountByYearRow` and `GameCountByYearExecutor`.
- Add repository SQL and `IChessRepository` support for counting games by `GameYear`.
- Register the new metric in DI.
- Add metric catalog description and parameter hints.
- Document the new metric in `EXAMPLE_ANALYSES.md` and update planning handoff notes.
- Add executor tests and include the metric in registry coverage.

## How to test

- `dotnet test "test\ServicesTests\ServicesTests.csproj" --no-restore -p:BaseOutputPath="obj\cursor-test\"`
- `dotnet test "ChessAnalyser.sln" --no-restore -p:BaseOutputPath="obj\cursor-test\"`

## Notes

The full test suite passes. Existing unrelated warnings remain in test projects.