### PR TITLE
fix: make metric player filters independent of colour.

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-05-11 (PLAN **§12.4** item 2: `PlayerResultSummary` metric added; HTTP auth **deferred** — see [PLAN.md §12.4](./PLAN.md).)
+**Last updated:** 2026-05-11 (analytics metric player filters now use independent player identity + colour dimensions; HTTP auth **deferred** — see [PLAN.md §12.4](./PLAN.md).)
 
 ---
 
@@ -24,7 +24,7 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 - **Done:** PGN parse → player resolution → bitboard positions per ply → persist **`Game`**, **`BoardPosition`**, **`Player`**, parse errors. GitHub Actions runs **`dotnet test`** on PRs.
 - **Housekeeping added:** schema-history scaffolding (`src/Migrations/History/` + `tools/export-db-history.ps1`) to snapshot current SQL object DDL after migrations.
-- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, and metrics discovery descriptions plus parameter hints. **Done (metrics surface):** `GameCountByEco`, `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`, and `PlayerResultSummary`. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
+- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, metrics discovery descriptions plus parameter hints, and independent metric player filters (`playerSurname`/`playerForenames` + `playerColour`). **Done (metrics surface):** `GameCountByEco`, `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`, and `PlayerResultSummary`. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
 
 ---
 

--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -118,16 +118,14 @@ metric:
 {
   "minGameYear": 1900,
   "maxGameYear": 1950,
-  "whitePlayerSurname": null,
-  "whitePlayerForenames": null,
-  "blackPlayerSurname": null,
-  "blackPlayerForenames": null,
+  "playerSurname": null,
+  "playerForenames": null,
+  "playerColour": "Any",
   "eco": null,
   "playerASurname": "Kasparov",
   "playerAForenames": "Garry",
   "playerBSurname": null,
   "playerBForenames": null,
-  "playerColour": "Any",
   "moveNumber": 1,
   "summaryPlyIndex": 4
 }
@@ -194,9 +192,9 @@ Content-Type: application/json
 - `summaryPlyIndex = 4` means the board snapshot after ply 4 using this repo's ply convention.
 - Material uses the configured `IPieceValues` implementation (`ClassicalPieceValues` today).
 - Player filters only narrow the game set before the side averages are calculated. For example,
-  filtering White player to `Kasparov, Garry` compares Kasparov's White-side material with the
-  Black-side material of his opponents in those same games. It does **not** compare Kasparov against
-  an all-player baseline or against another player independently.
+  filtering player to `Kasparov, Garry` with colour `White` compares Kasparov's White-side material
+  with the Black-side material of his opponents in those same games. It does **not** compare Kasparov
+  against an all-player baseline or against another player independently.
 - Use the planned player-comparison metric (PLAN §12.5) for player-vs-player or player-vs-baseline
   material questions.
 
@@ -289,7 +287,7 @@ checking whether move derivation is working and for exploring opening or player 
 In **Analytics metrics**:
 
 - Metric key: `KnightMoveDestinationFrequency`
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose a player plus colour
 
 Click **Run metric**.
 
@@ -342,7 +340,7 @@ to verify against `dbo.Game`.
 In **Analytics metrics**:
 
 - Metric key: `GameCountByEco`
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose a player plus colour
 
 Click **Run metric**.
 
@@ -391,7 +389,7 @@ and whether `GameYear` parsing looks sensible before running deeper year-based a
 In **Analytics metrics**:
 
 - Metric key: `GameCountByYear`
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose a player plus colour
 
 Click **Run metric**.
 
@@ -440,7 +438,7 @@ understanding whether the loaded data is balanced by outcome.
 In **Analytics metrics**:
 
 - Metric key: `GameCountByResult`
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose a player plus colour
 
 Click **Run metric**.
 
@@ -490,7 +488,7 @@ players in the corpus and checks whether player resolution is producing sensible
 In **Analytics metrics**:
 
 - Metric key: `GameCountByPlayer`
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose a player plus colour
 
 Click **Run metric**.
 
@@ -542,7 +540,7 @@ or Black. It is useful for quick leaderboard-style checks and for spotting unusu
 In **Analytics metrics**:
 
 - Metric key: `PlayerResultSummary`
-- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose White/Black players by name
+- Optional: set `minGameYear`, `maxGameYear`, `eco`, or choose a player plus colour
 
 Click **Run metric**.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -265,7 +265,7 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 
 | Concern | Decision |
 |---------|----------|
-| Execute | **`POST /api/analytics/metrics/execute`** (or `…/run`) with body `{ "metricKey": "…", "query": { … } }` mapping to **`AnalyticsQuery`** (`MinGameYear`, `MaxGameYear`, `WhitePlayerSurname`, `WhitePlayerForenames`, `BlackPlayerSurname`, `BlackPlayerForenames`, `Eco`, `SummaryPlyIndex`). |
+| Execute | **`POST /api/analytics/metrics/execute`** (or `…/run`) with body `{ "metricKey": "…", "query": { … } }` mapping to **`AnalyticsQuery`** (`MinGameYear`, `MaxGameYear`, independent `PlayerSurname` / `PlayerForenames` + `PlayerColour`, `Eco`, `SummaryPlyIndex`, and metric-specific player comparison fields). |
 | Discovery | **`GET /api/analytics/metrics`** returning **`IMetricRegistry.MetricKeys`** (and optional short descriptions from a static map or XML comments). |
 | Response | JSON projection of **`AnalyticsTableResult`**: `columnNames` + `rows` (array of arrays, or array of objects keyed by column — pick one and document). |
 | Errors | **404** or **400** for unknown **`metricKey`**; **400** for malformed filters. |

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -42,43 +42,46 @@ internal static class MetricCatalog
             "AverageMaterialByYearAndColour" =>
             [
                 "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: playerSurname/playerForenames plus playerColour = Any, White, or Black to narrow the game set.",
                 "Optional: summaryPlyIndex (defaults to 4).",
                 "Do not use for independent player-vs-player comparisons."
             ],
             "KnightMoveDestinationFrequency" =>
             [
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
+                "Optional: playerSurname/playerForenames plus playerColour = Any, White, or Black.",
                 "Returns numeric ToSquare values (0-63)."
             ],
             "GameCountByEco" =>
             [
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
+                "Optional: playerSurname/playerForenames plus playerColour = Any, White, or Black.",
                 "Rows with blank or missing ECO are excluded."
             ],
             "GameCountByYear" =>
             [
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
+                "Optional: playerSurname/playerForenames plus playerColour = Any, White, or Black.",
                 "Rows without a parsed GameYear are excluded."
             ],
             "GameCountByResult" =>
             [
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional side filters: whitePlayerSurname/Forenames, blackPlayerSurname/Forenames.",
+                "Optional: playerSurname/playerForenames plus playerColour = Any, White, or Black.",
                 "Stored winner codes are normalized to White, Black, Draw, or Unknown."
             ],
             "GameCountByPlayer" =>
             [
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional side filters narrow the game set before counting player appearances.",
+                "Optional player filter narrows the game set before counting player appearances.",
+                "playerColour = Any, White, or Black is independent from player identity.",
                 "Returns one row per resolved player with White, Black, and total game counts."
             ],
             "PlayerResultSummary" =>
             [
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional side filters narrow the game set before summarizing player results.",
+                "Optional player filter narrows the game set before summarizing player results.",
+                "playerColour = Any, White, or Black is independent from player identity.",
                 "Wins and losses are calculated from each player's perspective; draws score 0.5."
             ],
             "AverageMaterialByPlayerAtMove" =>

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -108,11 +108,17 @@
     </div>
     <label>eco (exact)</label>
     <input type="text" id="qEco" maxlength="16" placeholder="optional" />
-    <div id="sidePlayerFilters" class="metric-fields">
-      <p class="hint">Optional side filters for metrics that operate on games or moves.</p>
+    <div id="metricPlayerFilters" class="metric-fields">
+      <p class="hint">Optional player filter for metrics that operate on games or moves. Player identity and colour are independent: choose a player, then optionally restrict to games where they played White or Black.</p>
       <div class="row">
-        <label>White player <select id="qWhite"></select></label>
-        <label>Black player <select id="qBlack"></select></label>
+        <label>Player <select id="qPlayer"></select></label>
+        <label>Colour
+          <select id="qMetricPlayerColour">
+            <option value="Any">Any</option>
+            <option value="White">White</option>
+            <option value="Black">Black</option>
+          </select>
+        </label>
       </div>
     </div>
     <div id="sideMaterialFields" class="metric-fields">
@@ -239,8 +245,7 @@
 
       function loadPlayerOptions() {
         var selects = [
-          { element: document.getElementById('qWhite'), emptyText: 'Any player' },
-          { element: document.getElementById('qBlack'), emptyText: 'Any player' },
+          { element: document.getElementById('qPlayer'), emptyText: 'Any player' },
           { element: document.getElementById('qPlayerA'), emptyText: 'Select player A' },
           { element: document.getElementById('qPlayerB'), emptyText: 'All players' },
           { element: document.getElementById('gWhite'), emptyText: 'Any player' },
@@ -381,7 +386,7 @@
       var metricList = document.getElementById('metricList');
       var metricStatus = document.getElementById('metricStatus');
       var metricTableWrap = document.getElementById('metricTableWrap');
-      var sidePlayerFilters = document.getElementById('sidePlayerFilters');
+      var metricPlayerFilters = document.getElementById('metricPlayerFilters');
       var sideMaterialFields = document.getElementById('sideMaterialFields');
       var playerComparisonFields = document.getElementById('playerComparisonFields');
 
@@ -396,7 +401,7 @@
 
         playerComparisonFields.hidden = !isPlayerComparison;
         sideMaterialFields.hidden = !isSideMaterial;
-        sidePlayerFilters.hidden = isPlayerComparison || isSideMaterial;
+        metricPlayerFilters.hidden = isPlayerComparison;
 
         if (isPlayerComparison)
           metricStatus.textContent = 'Select Player A, optionally Player B, then choose colour and full move number.';
@@ -411,8 +416,8 @@
         var key = selectedMetricKey();
         var a = numVal('qMinYear');
         var b = numVal('qMaxYear');
-        var w = selectedPlayer('qWhite');
-        var bl = selectedPlayer('qBlack');
+        var metricPlayer = selectedPlayer('qPlayer');
+        var metricPlayerColour = strVal('qMetricPlayerColour');
         var playerA = selectedPlayer('qPlayerA');
         var playerB = selectedPlayer('qPlayerB');
         var eco = strVal('qEco');
@@ -434,14 +439,11 @@
           }
           if (playerColour != null) q.playerColour = playerColour;
           if (moveNumber != null) q.moveNumber = moveNumber;
-        } else if (key !== 'AverageMaterialByYearAndColour') {
-          if (w != null) {
-            q.whitePlayerSurname = w.surname;
-            q.whitePlayerForenames = w.forenames;
-          }
-          if (bl != null) {
-            q.blackPlayerSurname = bl.surname;
-            q.blackPlayerForenames = bl.forenames;
+        } else {
+          if (metricPlayer != null) {
+            q.playerSurname = metricPlayer.surname;
+            q.playerForenames = metricPlayer.forenames;
+            if (metricPlayerColour != null) q.playerColour = metricPlayerColour;
           }
         }
 

--- a/src/Interfaces/Analytics/AnalyticsQuery.cs
+++ b/src/Interfaces/Analytics/AnalyticsQuery.cs
@@ -9,17 +9,11 @@ public sealed class AnalyticsQuery
 
     public short? MaxGameYear { get; init; }
 
-    /// <summary>Exact match on White player's surname when set.</summary>
-    public string? WhitePlayerSurname { get; init; }
+    /// <summary>Exact match on a player's surname when set, independent of colour unless <see cref="PlayerColour"/> is also set.</summary>
+    public string? PlayerSurname { get; init; }
 
-    /// <summary>Exact match on White player's forenames when set. Empty string matches players with no forenames.</summary>
-    public string? WhitePlayerForenames { get; init; }
-
-    /// <summary>Exact match on Black player's surname when set.</summary>
-    public string? BlackPlayerSurname { get; init; }
-
-    /// <summary>Exact match on Black player's forenames when set. Empty string matches players with no forenames.</summary>
-    public string? BlackPlayerForenames { get; init; }
+    /// <summary>Exact match on a player's forenames when set. Empty string matches players with no forenames.</summary>
+    public string? PlayerForenames { get; init; }
 
     /// <summary>Exact match on <c>dbo.Game.Eco</c> when set.</summary>
     public string? Eco { get; init; }
@@ -36,7 +30,7 @@ public sealed class AnalyticsQuery
     /// <summary>Comparison player's forenames. Empty string matches players with no forenames.</summary>
     public string? PlayerBForenames { get; init; }
 
-    /// <summary>Colour mode for player-comparison metrics: <c>Any</c>, <c>White</c>, or <c>Black</c>.</summary>
+    /// <summary>Colour mode for player-aware metrics: <c>Any</c>, <c>White</c>, or <c>Black</c>.</summary>
     public string? PlayerColour { get; init; }
 
     /// <summary>User-facing full move number. For position summaries, full move N maps to ply <c>(N * 2) - 1</c>.</summary>

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -233,6 +233,21 @@ namespace Repositories
             return value.Trim();
         }
 
+        private static string NormalizePlayerColourFilter(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value)
+                || string.Equals(value.Trim(), "Any", StringComparison.OrdinalIgnoreCase))
+                return "Any";
+
+            if (string.Equals(value.Trim(), "White", StringComparison.OrdinalIgnoreCase))
+                return "White";
+
+            if (string.Equals(value.Trim(), "Black", StringComparison.OrdinalIgnoreCase))
+                return "Black";
+
+            throw new ArgumentException("playerColour must be Any, White, or Black.", "playerColour");
+        }
+
         /// <summary>
         /// Gets an open SQL connection.
         /// </summary>
@@ -568,10 +583,9 @@ namespace Repositories
                         PlyIndex = plyIndex,
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
-                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
-                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
-                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = query.Eco
                     },
                     cancellationToken: cancellationToken))).ToList();
@@ -593,10 +607,9 @@ namespace Repositories
                     {
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
-                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
-                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
-                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = query.Eco
                     },
                     cancellationToken: cancellationToken))).ToList();
@@ -618,10 +631,9 @@ namespace Repositories
                     {
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
-                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
-                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
-                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();
@@ -643,10 +655,9 @@ namespace Repositories
                     {
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
-                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
-                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
-                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();
@@ -668,10 +679,9 @@ namespace Repositories
                     {
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
-                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
-                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
-                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();
@@ -693,10 +703,9 @@ namespace Repositories
                     {
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
-                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
-                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
-                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();
@@ -718,10 +727,9 @@ namespace Repositories
                     {
                         MinGameYear = query.MinGameYear,
                         MaxGameYear = query.MaxGameYear,
-                        WhitePlayerSurname = NormalizeNonEmpty(query.WhitePlayerSurname),
-                        WhitePlayerForenames = NormalizeNamePart(query.WhitePlayerForenames),
-                        BlackPlayerSurname = NormalizeNonEmpty(query.BlackPlayerSurname),
-                        BlackPlayerForenames = NormalizeNamePart(query.BlackPlayerForenames),
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -114,8 +114,11 @@ namespace Repositories
             WHERE g.GameYear IS NOT NULL
               AND (@MinGameYear IS NULL OR g.GameYear >= @MinGameYear)
               AND (@MaxGameYear IS NULL OR g.GameYear <= @MaxGameYear)
-              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
-              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+              AND (
+                  @PlayerSurname IS NULL
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'White') AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'Black') AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+              )
               AND (@Eco IS NULL OR g.Eco = @Eco)
             GROUP BY g.GameYear
             ORDER BY g.GameYear;
@@ -134,8 +137,11 @@ namespace Repositories
             WHERE m.MovedPiece = 'N'
               AND (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
               AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
-              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
-              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+              AND (
+                  @PlayerSurname IS NULL
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'White') AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'Black') AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+              )
               AND (@Eco IS NULL OR g.Eco = @Eco)
             GROUP BY m.ToSquare
             ORDER BY MoveCount DESC, m.ToSquare;
@@ -154,8 +160,11 @@ namespace Repositories
               AND LTRIM(RTRIM(g.Eco)) <> ''
               AND (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
               AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
-              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
-              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+              AND (
+                  @PlayerSurname IS NULL
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'White') AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'Black') AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+              )
               AND (@Eco IS NULL OR g.Eco = @Eco)
             GROUP BY g.Eco
             ORDER BY GameCount DESC, g.Eco;
@@ -173,8 +182,11 @@ namespace Repositories
             WHERE g.GameYear IS NOT NULL
               AND (@MinGameYear IS NULL OR g.GameYear >= @MinGameYear)
               AND (@MaxGameYear IS NULL OR g.GameYear <= @MaxGameYear)
-              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
-              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+              AND (
+                  @PlayerSurname IS NULL
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'White') AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'Black') AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+              )
               AND (@Eco IS NULL OR g.Eco = @Eco)
             GROUP BY g.GameYear
             ORDER BY g.GameYear;
@@ -197,8 +209,11 @@ namespace Repositories
             LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
             WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
               AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
-              AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
-              AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+              AND (
+                  @PlayerSurname IS NULL
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'White') AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                  OR ((@PlayerColour = 'Any' OR @PlayerColour = 'Black') AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+              )
               AND (@Eco IS NULL OR g.Eco = @Eco)
             GROUP BY CASE g.Winner
                          WHEN 'W' THEN 'White'
@@ -224,8 +239,11 @@ namespace Repositories
                 LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
                 WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
                   AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
-                  AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
-                  AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+                  AND (
+                      @PlayerSurname IS NULL
+                      OR ((@PlayerColour = 'Any' OR @PlayerColour = 'White') AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR ((@PlayerColour = 'Any' OR @PlayerColour = 'Black') AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
                   AND (@Eco IS NULL OR g.Eco = @Eco)
             ),
             Appearance AS
@@ -270,8 +288,11 @@ namespace Repositories
                 LEFT JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
                 WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
                   AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
-                  AND (@WhitePlayerSurname IS NULL OR (wp.Surname = @WhitePlayerSurname AND (@WhitePlayerForenames IS NULL OR wp.Forenames = @WhitePlayerForenames)))
-                  AND (@BlackPlayerSurname IS NULL OR (bp.Surname = @BlackPlayerSurname AND (@BlackPlayerForenames IS NULL OR bp.Forenames = @BlackPlayerForenames)))
+                  AND (
+                      @PlayerSurname IS NULL
+                      OR ((@PlayerColour = 'Any' OR @PlayerColour = 'White') AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR ((@PlayerColour = 'Any' OR @PlayerColour = 'Black') AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
                   AND (@Eco IS NULL OR g.Eco = @Eco)
             ),
             Appearance AS

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -144,7 +144,7 @@ public class MetricRegistryAndExecutorsTests
         repo.Setup(r => r.GetKnightDestinationCountsAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<KnightDestinationCountRow>());
 
-        var query = new AnalyticsQuery { MinGameYear = 2000, Eco = "C00", WhitePlayerSurname = "Tal", WhitePlayerForenames = "Mikhail" };
+        var query = new AnalyticsQuery { MinGameYear = 2000, Eco = "C00", PlayerSurname = "Tal", PlayerForenames = "Mikhail", PlayerColour = "Any" };
         var sut = new KnightMoveDestinationFrequencyExecutor(repo.Object);
         await sut.ExecuteAsync(query);
 
@@ -152,8 +152,9 @@ public class MetricRegistryAndExecutorsTests
             It.Is<AnalyticsQuery>(q =>
                 q.MinGameYear == 2000
                 && q.Eco == "C00"
-                && q.WhitePlayerSurname == "Tal"
-                && q.WhitePlayerForenames == "Mikhail"),
+                && q.PlayerSurname == "Tal"
+                && q.PlayerForenames == "Mikhail"
+                && q.PlayerColour == "Any"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -187,8 +188,9 @@ public class MetricRegistryAndExecutorsTests
         var query = new AnalyticsQuery
         {
             MinGameYear = 1980,
-            WhitePlayerSurname = "Kasparov",
-            WhitePlayerForenames = "Garry",
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            PlayerColour = "White",
             Eco = "B90"
         };
         var sut = new GameCountByEcoExecutor(repo.Object);
@@ -198,8 +200,9 @@ public class MetricRegistryAndExecutorsTests
         repo.Verify(r => r.GetGameCountsByEcoAsync(
             It.Is<AnalyticsQuery>(q =>
                 q.MinGameYear == 1980
-                && q.WhitePlayerSurname == "Kasparov"
-                && q.WhitePlayerForenames == "Garry"
+                && q.PlayerSurname == "Kasparov"
+                && q.PlayerForenames == "Garry"
+                && q.PlayerColour == "White"
                 && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -235,8 +238,9 @@ public class MetricRegistryAndExecutorsTests
         {
             MinGameYear = 1980,
             MaxGameYear = 1990,
-            BlackPlayerSurname = "Karpov",
-            BlackPlayerForenames = "Anatoly",
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly",
+            PlayerColour = "Black",
             Eco = "B90"
         };
         var sut = new GameCountByYearExecutor(repo.Object);
@@ -247,8 +251,9 @@ public class MetricRegistryAndExecutorsTests
             It.Is<AnalyticsQuery>(q =>
                 q.MinGameYear == 1980
                 && q.MaxGameYear == 1990
-                && q.BlackPlayerSurname == "Karpov"
-                && q.BlackPlayerForenames == "Anatoly"
+                && q.PlayerSurname == "Karpov"
+                && q.PlayerForenames == "Anatoly"
+                && q.PlayerColour == "Black"
                 && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -284,8 +289,9 @@ public class MetricRegistryAndExecutorsTests
         {
             MinGameYear = 1980,
             MaxGameYear = 1990,
-            WhitePlayerSurname = "Kasparov",
-            WhitePlayerForenames = "Garry",
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            PlayerColour = "Any",
             Eco = "B90"
         };
         var sut = new GameCountByResultExecutor(repo.Object);
@@ -296,8 +302,9 @@ public class MetricRegistryAndExecutorsTests
             It.Is<AnalyticsQuery>(q =>
                 q.MinGameYear == 1980
                 && q.MaxGameYear == 1990
-                && q.WhitePlayerSurname == "Kasparov"
-                && q.WhitePlayerForenames == "Garry"
+                && q.PlayerSurname == "Kasparov"
+                && q.PlayerForenames == "Garry"
+                && q.PlayerColour == "Any"
                 && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -336,8 +343,9 @@ public class MetricRegistryAndExecutorsTests
         {
             MinGameYear = 1980,
             MaxGameYear = 1990,
-            WhitePlayerSurname = "Kasparov",
-            WhitePlayerForenames = "Garry",
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            PlayerColour = "White",
             Eco = "B90"
         };
         var sut = new GameCountByPlayerExecutor(repo.Object);
@@ -348,8 +356,9 @@ public class MetricRegistryAndExecutorsTests
             It.Is<AnalyticsQuery>(q =>
                 q.MinGameYear == 1980
                 && q.MaxGameYear == 1990
-                && q.WhitePlayerSurname == "Kasparov"
-                && q.WhitePlayerForenames == "Garry"
+                && q.PlayerSurname == "Kasparov"
+                && q.PlayerForenames == "Garry"
+                && q.PlayerColour == "White"
                 && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -391,8 +400,9 @@ public class MetricRegistryAndExecutorsTests
         {
             MinGameYear = 1980,
             MaxGameYear = 1990,
-            WhitePlayerSurname = "Kasparov",
-            WhitePlayerForenames = "Garry",
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            PlayerColour = "White",
             Eco = "B90"
         };
         var sut = new PlayerResultSummaryExecutor(repo.Object);
@@ -403,8 +413,9 @@ public class MetricRegistryAndExecutorsTests
             It.Is<AnalyticsQuery>(q =>
                 q.MinGameYear == 1980
                 && q.MaxGameYear == 1990
-                && q.WhitePlayerSurname == "Kasparov"
-                && q.WhitePlayerForenames == "Garry"
+                && q.PlayerSurname == "Kasparov"
+                && q.PlayerForenames == "Garry"
+                && q.PlayerColour == "White"
                 && q.Eco == "B90"),
             It.IsAny<CancellationToken>()), Times.Once);
     }


### PR DESCRIPTION
## Summary

Fix metric player filtering so player identity and colour are separate dimensions. Metrics now use `playerSurname` / `playerForenames` plus optional `playerColour`, instead of conflating player identity with White/Black side filters.

## Changes

- Replace side-specific metric query fields with independent player identity fields.
- Update metric SQL to filter a selected player as White, Black, or either colour.
- Update the metrics UI to show one player selector plus a colour selector.
- Keep White/Black player filters for the Games browser, where side-specific filtering is intentional.
- Update discovery hints, docs, plan notes, and executor tests.

## How to test

- `dotnet test "test\ServicesTests\ServicesTests.csproj" --no-restore -p:BaseOutputPath="obj\cursor-test\"`
- `dotnet test "ChessAnalyser.sln" --no-restore -p:BaseOutputPath="obj\cursor-test\"`

## Notes

The full test suite passes. Existing unrelated warnings remain in test projects.