### PR TITLE
Added new metrics.

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-05-11 (analytics metric player filters now use independent player identity + colour dimensions; HTTP auth **deferred** — see [PLAN.md §12.4](./PLAN.md).)
+**Last updated:** 2026-06-11 (Phase 2 style metrics implemented: `BishopPairFrequency`, `MinorPieceComposition`.)
 
 ---
 
@@ -13,7 +13,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 | File | Role |
 |------|------|
 | [DESIGN.md](./DESIGN.md) | Requirements and locked decisions (facts, dimensions, C# vs SQL, rollups, year rules). |
-| [PLAN.md](./PLAN.md) | Implementation plan; **§11** (closed) + **§12** (metrics HTTP API) + **§12.4** (current suggested slice). |
+| [PLAN.md](./PLAN.md) | Implementation plan; **§11** (closed) + **§12** (metrics HTTP API) + **§12.6** (playing-style metrics backlog). |
+| [STYLE_METRICS.md](./STYLE_METRICS.md) | Style research, literature, metric catalogue, profile combinations, caveats. |
 | **AGENT_CONTEXT.md** (this file) | Current progress and **recommended next small step**. |
 
 **Global process skill:** `~/.cursor/skills/dpi-workflow/` (`dpi-workflow`) — 80/20 DESIGN+PLAN vs IMPLEMENT; applies in any repo.
@@ -24,15 +25,15 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 - **Done:** PGN parse → player resolution → bitboard positions per ply → persist **`Game`**, **`BoardPosition`**, **`Player`**, parse errors. GitHub Actions runs **`dotnet test`** on PRs.
 - **Housekeeping added:** schema-history scaffolding (`src/Migrations/History/` + `tools/export-db-history.ps1`) to snapshot current SQL object DDL after migrations.
-- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, metrics discovery descriptions plus parameter hints, and independent metric player filters (`playerSurname`/`playerForenames` + `playerColour`). **Done (metrics surface):** `GameCountByEco`, `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`, and `PlayerResultSummary`. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
+- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, metrics discovery descriptions plus parameter hints, and independent metric player filters (`playerSurname`/`playerForenames` + `playerColour`). **Done (metrics surface):** `GameCountByEco`, `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`, `PlayerResultSummary`, `AverageCastlingPly`, `AverageMaterialVolatility`, `BishopPairFrequency`, `MinorPieceComposition`. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
 
 ---
 
 ## 3. Recommended next step (small slice)
 
-**Do next:** No fixed planned PR is queued. Choose the next concrete analysis question before adding another metric, or do a small cleanup/test-hardening slice if one is called out by the maintainer.
+**Do next:** Implement **Phase 3** of [PLAN.md §12.6](./PLAN.md): `CaptureRate`, then `QueenTradeRate`.
 
-**Then:** Continue §12.4 item 4 tests as needed for each new metric. Optionally refresh [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) if deriver/summary hot paths change.
+**Then:** Phase 4 (`CentreMoveRate`, `ForwardMoveRate`) per §12.6.
 
 **Do not prioritize yet:** Dedicated HTTP **auth / rate limits** for `AnalyticsMetricsController` — **out of scope** until there is a **deployment or network exposure** plan (then treat as blocking; update PLAN §12.1 / §13). Optional hygiene: bind the dev host to **localhost** only.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -159,6 +159,9 @@ Detailed interfaces belong in PLAN.md; this section captures the **design intent
 
 - Optional future metric: **material gained** vs opening (explicitly separate from F-1).
 - Optional **“unknown year”** bucket if you later want visibility into games dropped from year reports.
+- **Playing-style metrics** (move/position fingerprints without engine evaluation): research in
+  [STYLE_METRICS.md](./STYLE_METRICS.md); implementation sequence in [PLAN.md §12.6](./PLAN.md).
+  First targets: `AverageCastlingPly`, `MaterialVolatility`.
 
 ---
 

--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -110,6 +110,13 @@ Current metric keys:
 - `GameCountByPlayer`
 - `PlayerResultSummary`
 - `AverageMaterialByPlayerAtMove`
+- `AverageCastlingPly`
+- `AverageMaterialVolatility`
+- `BishopPairFrequency`
+- `MinorPieceComposition`
+
+**Planned:** further playing-style metrics — see [STYLE_METRICS.md](./STYLE_METRICS.md) and
+[PLAN.md §12.6](./PLAN.md) Phase 3 onward.
 
 Metrics support the shared `AnalyticsQuery` filter shape where the filter is meaningful for that
 metric:
@@ -652,7 +659,192 @@ ORDER BY g.Id;
 
 ---
 
-## 14. Adding a new example analysis to this document
+## 14. Example analysis: average castling ply (playing style)
+
+### Question
+
+At what half-move does a player typically castle for the first time?
+
+### Why it is useful
+
+Early castling often indicates a pragmatic, king-safety-first approach; late or absent castling can
+signal riskier structures. Compare players with the same year and colour filters.
+
+### Run it in the UI
+
+In **Analytics metrics**:
+
+- Metric key: `AverageCastlingPly`
+- **Required:** choose a player (surname; forenames recommended)
+- Optional: `playerColour`, `minGameYear`, `maxGameYear`, `eco`
+
+Click **Run metric**.
+
+### Equivalent HTTP request
+
+```http
+POST /api/analytics/metrics/execute
+Content-Type: application/json
+```
+
+```json
+{
+  "metricKey": "AverageCastlingPly",
+  "query": {
+    "playerSurname": "Petrosian",
+    "playerForenames": "Tigran",
+    "playerColour": "Any",
+    "minGameYear": 1950,
+    "maxGameYear": 1970
+  }
+}
+```
+
+### Result columns
+
+- `Player` — filtered player name
+- `GamesWithCastling` — games where the player castled at least once
+- `AverageCastlingPly` — mean ply of first castle (games without castling excluded from the average)
+
+### Notes
+
+- Requires `dbo.GameMove` with castling flags populated.
+- `playerSurname` is required; the API returns `400` if omitted.
+- Pair with `UncastledKingRate` (planned Phase 5) for a fuller king-safety picture.
+
+---
+
+## 15. Example analysis: average material volatility (playing style)
+
+### Question
+
+How much does the material balance swing during a player's games?
+
+### Why it is useful
+
+High volatility suggests dynamic, imbalanced fighting; low volatility suggests stable positional
+play. Useful for comparing Tal-like complexity against Karpov-like stability.
+
+### Run it in the UI
+
+In **Analytics metrics**:
+
+- Metric key: `AverageMaterialVolatility`
+- **Required:** choose a player
+- Optional: `playerColour`, `minGameYear`, `maxGameYear`, `eco`
+- Optional ply window: pass `minPlyIndex` / `maxPlyIndex` in the HTTP body (e.g. middlegame 15–40)
+
+Click **Run metric**.
+
+### Equivalent HTTP request
+
+```http
+POST /api/analytics/metrics/execute
+Content-Type: application/json
+```
+
+```json
+{
+  "metricKey": "AverageMaterialVolatility",
+  "query": {
+    "playerSurname": "Tal",
+    "playerForenames": "Mikhail",
+    "playerColour": "Any",
+    "minPlyIndex": 15,
+    "maxPlyIndex": 40
+  }
+}
+```
+
+### Result columns
+
+- `Player` — filtered player name
+- `GameCount` — games with at least two position summaries in the ply window (needed for std dev)
+- `AverageMaterialVolatility` — mean per-game sample standard deviation of signed material balance
+  from the player's perspective
+
+### Notes
+
+- Balance is `WhiteMaterial - BlackMaterial` when the player had White, reversed when Black.
+- Omit `minPlyIndex` / `maxPlyIndex` to include all plies (including ply `-1`).
+- Requires `dbo.GamePositionSummary` rows.
+
+---
+
+## 16. Example analysis: bishop pair frequency (playing style)
+
+### Question
+
+How often does a player retain both bishops during the middlegame?
+
+### Run it in the UI
+
+- Metric key: `BishopPairFrequency`
+- **Required:** player surname (and forenames recommended)
+- Optional: `playerColour`, year/ECO filters
+- Optional: `minPlyIndex` / `maxPlyIndex` (default **15–30** when both omitted)
+
+### Equivalent HTTP request
+
+```json
+{
+  "metricKey": "BishopPairFrequency",
+  "query": {
+    "playerSurname": "Karpov",
+    "playerForenames": "Anatoly",
+    "playerColour": "Any"
+  }
+}
+```
+
+### Result columns
+
+- `Player`, `GameCount`, `AverageBishopPairFrequency` (0–1), `MinPlyIndex`, `MaxPlyIndex`
+
+---
+
+## 17. Example analysis: minor piece composition (playing style)
+
+### Question
+
+Does the player tend toward bishops or knights on the board in the middlegame?
+
+### Run it in the UI
+
+- Metric key: `MinorPieceComposition`
+- **Required:** player surname
+- Optional ply window (default **15–30**)
+
+### Equivalent HTTP request
+
+```json
+{
+  "metricKey": "MinorPieceComposition",
+  "query": {
+    "playerSurname": "Tal",
+    "playerForenames": "Mikhail",
+    "minPlyIndex": 15,
+    "maxPlyIndex": 30
+  }
+}
+```
+
+### Result columns
+
+- `Player`, `GameCount`, `AverageMinorPieceDelta` (positive = bishop-oriented), `MinPlyIndex`, `MaxPlyIndex`
+
+---
+
+## 18. Playing-style metrics (overview)
+
+| Resource | Contents |
+|----------|----------|
+| [STYLE_METRICS.md](./STYLE_METRICS.md) | Literature review, style dimensions, profile combinations, caveats |
+| [PLAN.md §12.6](./PLAN.md) | Ordered implementation backlog (Phases 3–9) |
+
+---
+
+## 19. Adding a new example analysis to this document
 
 Use this template:
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,7 +1,7 @@
 # ChessAnalyser — Board-position analytics (PLAN)
 
 **Location:** **`docs/`** — alongside [DESIGN.md](./DESIGN.md) and [AGENT_CONTEXT.md](./AGENT_CONTEXT.md).  
-**Document status:** Stage 2 (design guide) + **Stage 3 complete** (§11 checklist, 2026-05-10) + **Stage 4 §12 checklist complete** (metrics HTTP API + DESIGN F-9 / Q7 alignment). **Active implementation direction:** §12.4 (first: **unified `wwwroot` web UI** for local daily use; then metrics catalog extension; HTTP auth **deferred** while the app stays local-only / undeployed).  
+**Document status:** Stage 2 (design guide) + **Stage 3 complete** (§11 checklist, 2026-05-10) + **Stage 4 §12 checklist complete** (metrics HTTP API + DESIGN F-9 / Q7 alignment). **Active implementation direction:** §12.6 playing-style metrics (first: `AverageCastlingPly`, `MaterialVolatility`); HTTP auth **deferred** while the app stays local-only / undeployed.  
 **Authority:** Implements [DESIGN.md](./DESIGN.md). Update this plan when scope or decisions change.
 
 ---
@@ -16,6 +16,7 @@
 | §8 Q3 (year omitted if unknown) | §5.1, §7.2 |
 | §8.5 C# domain logic; SQL for access / trivial aggregates | §5.4, §8 |
 | F-9 / Q7 (programmatic access) | §12 (Stage 4 — HTTP surface for existing registry) |
+| Playing-style metrics (research) | [STYLE_METRICS.md](./STYLE_METRICS.md); implementation §12.6 |
 
 ---
 
@@ -292,10 +293,15 @@ Items **1–13** are **complete** in source for the board-position analytics gro
 
 **Suggested next work (PR-sized, in order of value):**
 
-1. **Unified local web UI (`wwwroot`)** — make the static app the **primary** surface for solo use: PGN path, **LoadGames**, progress polling, **CancelLoad** (already partly on `index.html`); add sections that call existing JSON APIs for **metrics discovery + execute** (`GET/POST /api/analytics/metrics/…`) and **paged GetGames** (`GET /Analyser/GetGames` with filters) so routine work does not require Swagger. Keep **Swagger** as an optional dev “API docs” link, not part of the default workflow.
-2. [x] **Extend the metrics surface** — add **`IMetricExecutor`** implementations for additional questions you care about (same patterns as the two reference metrics: parameterized repository reads, tabular `AnalyticsTableResult` only). Register them in **`IMetricRegistry`** / DI. Current additions include `GameCountByEco`, `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`, and `PlayerResultSummary`.
-3. [x] **Improve discovery** — enrich **`GET /api/analytics/metrics`** with clearer descriptions and parameter hints so the web UI and Swagger stay usable as the catalog grows.
-4. **Tests** — per-metric executor tests with mocked **`IChessRepository`** (and API smoke tests for new keys), following §12.3; add light **Playwright** or manual test notes for the unified web UI if you introduce non-trivial client script.
+1. [x] **Unified local web UI (`wwwroot`)** — primary surface for PGN load, metrics, and paged games.
+2. [x] **Extend the metrics surface** — corpus and player summary metrics (`GameCountByEco`,
+   `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`,
+   `PlayerResultSummary`).
+3. [x] **Improve discovery** — descriptions and parameter hints on `GET /api/analytics/metrics`.
+4. **Playing-style metrics** — follow **[§12.6](./PLAN.md)** in order: first `AverageCastlingPly`,
+   then `MaterialVolatility`, then Phases 2–8. Research background: [STYLE_METRICS.md](./STYLE_METRICS.md).
+5. **Tests** — per-metric executor tests with mocked **`IChessRepository`** (and API smoke tests for
+   new keys), following §12.3.
 
 **Optional:** Record a fresh materialization throughput line in [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) when you change hot paths in the deriver or summary factory.
 
@@ -363,6 +369,234 @@ Implement player material comparison as a separate sequence of PRs:
 
 ---
 
+### 12.6 Playing-style metrics (planned PR sequence)
+
+**Decision (2026):** Extend the metrics catalog toward **playing-style fingerprints** — behavioural
+patterns derived from `GameMove`, `GamePositionSummary`, and `Game` **without engine evaluation**.
+Research background, literature references, profile combinations, and interpretation caveats are
+documented in [STYLE_METRICS.md](./STYLE_METRICS.md).
+
+**Shared conventions for §12.6 metrics:**
+
+- Follow existing **`IMetricExecutor`** + parameterized **`IChessRepository`** read pattern (§5.3.4,
+  §8).
+- Player filters use **`AnalyticsQuery.PlayerSurname`**, **`PlayerForenames`**, and
+  **`PlayerColour`** (`Any` / `White` / `Black`) — independent identity and colour (see
+  `fix/independent-metric-player-filter`).
+- Year / ECO filters reuse existing `AnalyticsQuery` fields where applicable.
+- Register each executor in **`Program.cs`**; add **`MetricCatalog`** description + parameter hints;
+  add executor tests with mocked repository; add an [EXAMPLE_ANALYSES.md](./EXAMPLE_ANALYSES.md)
+  entry when the metric ships.
+- **Player filter required** for per-player style metrics unless the metric is explicitly corpus-wide
+  (none in the first phases).
+- Prefer **one PR per metric** (or one PR per small phase) to keep review small.
+
+**Optional query extensions** (add to `AnalyticsQuery` when the first metric in a phase needs them):
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `minPlyIndex` / `maxPlyIndex` | `int?` | Restrict move or position reads to a ply window (e.g. middlegame 15–40). |
+| `queenTradeMaxPly` | `int?` | For `QueenTradeRate` — queens exchanged on or before this ply count as “early trade”. |
+| `shortDrawMaxPly` | `int?` | For `ShortDrawRate` — draws at or below this length count as “short”. |
+| `ecoTopN` | `int?` | For `EcoConcentration` — N largest ECO families (default 3). |
+
+Document defaults in `MetricCatalog.GetParameterHints` when added.
+
+---
+
+#### Phase 1 — castling tempo and material volatility (implement first)
+
+1. [x] **`AverageCastlingPly`**
+   - **Question:** At what half-move does a player typically castle?
+   - **Style signal:** Early castling ≈ pragmatic / king-safety-first; late or absent ≈ riskier or
+     more aggressive structures (ChessBase **Risk**; thesis game-structure features).
+   - **Data:** `GameMove` where `IsCastlingKingside = 1 OR IsCastlingQueenside = 1`, joined to
+     `Game` + `Player` for the filtered side.
+   - **Per game:** `MIN(PlyIndex)` of the player's first castling move (one value per player per
+     game).
+   - **Aggregate:** `AVG(castling_ply)` over games where the player castled at least once.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GamesWithCastling`, `AverageCastlingPly`
+     (nullable decimal; round to 1 decimal in presentation layer if desired).
+   - **Exclude** games where the player never castled from the average (report
+     `GamesWithCastling` separately; pair with Phase 5 `UncastledKingRate`).
+   - **Filters:** `playerSurname`, `playerForenames`, `playerColour`, `minGameYear`, `maxGameYear`,
+     `eco`.
+   - **Tests:** mock repository — player castles once at ply 6 and once at ply 10 → avg 8; games
+     without castling excluded from average but counted correctly.
+
+2. [x] **`MaterialVolatility`** (metric key: `AverageMaterialVolatility`)
+   - **Question:** How much does the material balance swing during a player's games?
+   - **Style signal:** High volatility ≈ dynamic / imbalanced fighting; low ≈ stable positional grind
+     (thesis **Mstd** / material-dynamics features; jk_182 imbalance axis).
+   - **Data:** `GamePositionSummary` per ply, joined to `Game` for player side.
+   - **Per game:** For each ply `p`, compute signed balance from the **player's perspective**:
+     - White player: `WhiteMaterial - BlackMaterial`
+     - Black player: `BlackMaterial - WhiteMaterial`
+     - `playerColour = Any`: use side the filtered player had in that game (two rows per game if the
+       same person played both colours — rare; normally filter colour or one row per game).
+     - `STDDEV_SAMP(balance)` across all plies in the game (include ply `-1` through terminal ply,
+       or document exclusion of ply `-1` — prefer **include all plies** for consistency).
+   - **Aggregate:** `AVG(per_game_stddev)` across games.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageMaterialVolatility`.
+   - **Filters:** `playerSurname`, `playerForenames`, `playerColour`, `minGameYear`, `maxGameYear`,
+     `eco`, optional `minPlyIndex` / `maxPlyIndex` to restrict which plies enter the std-dev (e.g.
+     middlegame only).
+   - **SQL note:** `STDDEV_SAMP` per game may be computed in SQL over grouped rows or in C# after a
+     narrow read — choose per §8 (trivial scalar aggregate on summary columns is allowed).
+   - **Tests:** flat balance → volatility 0; single spike → positive volatility; ply window respected.
+
+---
+
+#### Phase 2 — piece philosophy
+
+3. [x] **`BishopPairFrequency`**
+   - **Question:** How often does a player retain both bishops in the middlegame?
+   - **Data:** `GamePositionSummary` — count plies in window where `WhiteBishopCount = 2` (or
+     `BlackBishopCount = 2`) for the player's side.
+   - **Per game:** `plies_with_bishop_pair / plies_in_window` (ratio 0–1).
+   - **Aggregate:** `AVG(ratio)` across games.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageBishopPairFrequency`.
+   - **Default ply window:** plies 15–30 (override via `minPlyIndex` / `maxPlyIndex`).
+   - **Filters:** player + year + ECO + ply window.
+
+4. [x] **`MinorPieceComposition`**
+   - **Question:** Does the player tend toward bishops or knights on the board?
+   - **Data:** `GamePositionSummary` in ply window.
+   - **Per ply (player side):** `bishop_count - knight_count`; average across plies in window, then
+     average across games.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageMinorPieceDelta`
+     (positive = bishop-oriented).
+   - **Default ply window:** plies 15–30.
+
+---
+
+#### Phase 3 — exchange temperament
+
+5. [ ] **`CaptureRate`**
+   - **Question:** What fraction of the player's moves are captures?
+   - **Data:** `GameMove` where `MovingSide` matches the player's colour in that game.
+   - **Per game:** `COUNT(captures) / COUNT(moves)` where capture ⇔ `CapturedPiece IS NOT NULL`.
+   - **Aggregate:** `AVG(per_game_rate)`.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageCaptureRate`.
+   - **Optional:** `minPlyIndex` / `maxPlyIndex` on move ply.
+
+6. [ ] **`QueenTradeRate`**
+   - **Question:** How often are queens exchanged early?
+   - **Data:** `GamePositionSummary` or `GameMove` — detect first ply where both
+     `WhiteQueenCount` and `BlackQueenCount` are not both 1 (or either queen count drops to 0).
+   - **Per game:** `1` if queen trade occurred on or before `queenTradeMaxPly` (default **40**),
+     else `0`.
+   - **Aggregate:** `AVG` → proportion of games with early queen trade.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `QueenTradeRate`,
+     `QueenTradeMaxPly` (echo parameter used).
+
+---
+
+#### Phase 4 — spatial aggression
+
+7. [ ] **`CentreMoveRate`**
+   - **Question:** How often does a player play to central squares?
+   - **Data:** `GameMove` — `ToSquare` in centre set **{d4, d5, e4, e5}** (square indices 27, 28,
+     35, 36 with a1 = 0).
+   - **Per game:** centre moves / total moves by player.
+   - **Aggregate:** `AVG(per_game_rate)`.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageCentreMoveRate`.
+   - **Optional v2:** extend centre ring to c3–f6 (document if added).
+
+8. [ ] **`ForwardMoveRate`**
+   - **Question:** How often does a player advance into the opponent's half?
+   - **Data:** `GameMove` — `ToSquare` rank index (0–7) compared to moving side (White: rank ≥ 4;
+     Black: rank ≤ 3).
+   - **Per game:** forward moves / total moves.
+   - **Aggregate:** `AVG(per_game_rate)`.
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageForwardMoveRate`.
+
+---
+
+#### Phase 5 — king safety extensions
+
+9. [ ] **`CastlingSidePreference`**
+   - **Data:** `GameMove` castling rows for the player.
+   - **Per game:** first castle only — kingside vs queenside.
+   - **Aggregate:** `KingsideRate`, `QueensideRate` (proportions among games with castling).
+   - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GamesWithCastling`, `KingsideRate`,
+     `QueensideRate`.
+
+10. [ ] **`OppositeSideCastlingRate`**
+    - **Data:** first castling ply and side per colour per game from `GameMove`.
+    - **Per game:** `1` if White and Black castled to different wings (kingside = K-side file,
+      queenside = Q-side), else `0` (exclude games where either side never castled, or report
+      separate `EligibleGameCount`).
+    - **Aggregate:** proportion over eligible games.
+    - **Result columns:** `EligibleGameCount`, `OppositeSideCastlingRate`.
+
+11. [ ] **`UncastledKingRate`**
+    - **Per game:** `1` if the filtered player never castled, else `0`.
+    - **Aggregate:** proportion.
+    - **Result columns:** `GameCount`, `UncastledKingRate`.
+
+---
+
+#### Phase 6 — queen timing
+
+12. [ ] **`FirstQueenMovePly`**
+    - **Data:** `GameMove` where `MovedPiece = 'Q'` for the player's side.
+    - **Per game:** `MIN(PlyIndex)` of queen moves; normalize optionally as
+      `first_queen_ply / max_ply` (document if normalization is included — v1 can report raw ply).
+    - **Aggregate:** `AVG(first_queen_ply)` over games where the queen moved at least once.
+    - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GamesWithQueenMove`,
+      `AverageFirstQueenMovePly`.
+
+---
+
+#### Phase 7 — game shape
+
+13. [ ] **`AverageGameLength`**
+    - **Data:** `MAX(PlyIndex)` from `GamePositionSummary` or move count per game.
+    - **Aggregate:** `AVG(max_ply)` for games involving the filtered player.
+    - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageGameLengthPly`.
+
+14. [ ] **`ShortDrawRate`**
+    - **Data:** `Game.Winner` draw detection + game length.
+    - **Per game:** among draws only, `1` if `max_ply <= shortDrawMaxPly` (default **20**), else `0`.
+    - **Aggregate:** proportion of draws that are short (ChessBase **Fighting Spirit** proxy).
+    - **Result columns:** `DrawCount`, `ShortDrawRate`, `ShortDrawMaxPly`.
+
+---
+
+#### Phase 8 — repertoire shape
+
+15. [ ] **`EcoDiversity`**
+    - **Data:** `Game.Eco` for games involving the player.
+    - **Aggregate:** `COUNT(DISTINCT Eco)` (exclude null ECO).
+    - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `EcoDiversity`.
+
+16. [ ] **`EcoConcentration`**
+    - **Data:** `Game.Eco` frequency table per player.
+    - **Aggregate:** sum of game shares of the top `ecoTopN` ECO codes (default **3**).
+    - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `EcoConcentration`,
+      `EcoTopN`.
+
+---
+
+#### Phase 9 — materialization extensions (defer until Phases 1–8 stable)
+
+17. [ ] **`IsCheck`** on `GameMove` (derive at materialization from board diff) → enables future
+    **CheckRate** metric.
+18. [ ] **Game phase** label on `GamePositionSummary` (opening / middlegame / endgame by piece-count
+    rules) → enables **PhaseDistribution** metric.
+19. [ ] **`PlayerStyleProfile`** — composite metric returning a small vector of normalized scores
+    (aggression, positional, simplifier, risk) from a subset of the above; optional PCA later.
+
+**Engine-dependent (out of scope for §12.6):** ACPL, move accuracy, position sharpness/WDL,
+sound sacrifice detection — see [STYLE_METRICS.md §4 Phase 9](./STYLE_METRICS.md) and §14 below.
+
+**Validation:** After Phase 1, compare two players with contrasting reputations (e.g. Tal vs
+Petrosian) on `AverageCastlingPly` and `MaterialVolatility` with the same filters; see
+[STYLE_METRICS.md §7](./STYLE_METRICS.md).
+
+---
+
 ## 13. Risks and mitigations
 
 | Risk | Mitigation |
@@ -379,7 +613,9 @@ Implement player material comparison as a separate sequence of PRs:
 - “Material gained since opening” as a separate metric (DESIGN §9).
 - Unknown-year bucket (DESIGN §9).
 - Arbitrary SQL / raw table dumps from HTTP clients (keep **registered metrics + parameterized repository reads** only).
+- **Engine-based style metrics** (ACPL, sharpness/WDL, sound sacrifice classification) — deferred;
+  see [STYLE_METRICS.md](./STYLE_METRICS.md) and PLAN §12.6 Phase 9.
 
 ---
 
-*End of PLAN.md. Stage 3 (§11) is complete; Stage 4 **§12** is complete; follow **§12.4** for general metrics/UI work and **§12.5** for the planned player material comparison sequence until deployment plans change.*
+*End of PLAN.md. Stage 3 (§11) is complete; Stage 4 **§12** is complete. **Active backlog:** §12.6 playing-style metrics (start with `AverageCastlingPly`, `MaterialVolatility`); §12.4 for general UI/tests; §12.5 player material comparison is complete.*

--- a/docs/STYLE_METRICS.md
+++ b/docs/STYLE_METRICS.md
@@ -1,0 +1,171 @@
+# ChessAnalyser — playing-style metrics (research)
+
+**Location:** `docs/` alongside [DESIGN.md](./DESIGN.md), [PLAN.md](./PLAN.md), and [EXAMPLE_ANALYSES.md](./EXAMPLE_ANALYSES.md).  
+**Purpose:** Capture how chess playing style is assessed in the literature and tools, what ChessAnalyser can measure **without an engine**, and how individual metrics combine into interpretable profiles.  
+**Implementation backlog:** [PLAN.md §12.6](./PLAN.md) (ordered PR sequence).
+
+---
+
+## 1. Why style is hard to measure
+
+Playing style is not a single scalar. Analysts and researchers use **many behavioural fingerprints** and compare players in profile space. A metric that works in isolation (e.g. capture rate) is often confounded by **opening choice**, **opponent strength**, and **era**. Style metrics should therefore:
+
+- Be computed **per player** with explicit `playerSurname` / `playerForenames` and optional `playerColour`.
+- Prefer **middlegame windows** (e.g. plies 15–40) when opening noise should be reduced.
+- Require **sufficient sample size** (dozens of games; literature often excludes short draws and out-of-prime years).
+- Be read as **choices**, not **quality** — without engine evaluation, high capture rate does not distinguish Tal from a blunderer.
+
+---
+
+## 2. External references (how others assess style)
+
+| Source | Method | Dimensions relevant to ChessAnalyser |
+|--------|--------|--------------------------------------|
+| [ChessBase Style Report](https://help.chessbase.com/CBase/18/Eng/criteria_of_the_style_report.htm) | Fast heuristics, minimal engine | Theory/repertoire, fighting spirit, aggressiveness, risk, positional play, endgame skill |
+| [jk_182 — Identifying the Style of Different Players](https://lichess.org/@/jk_182/blog/identifying-the-style-of-different-players/WnfPnBli) | 43 move-derived variables, PCA (no engine) | Pawn vs piece moves, centre play, king attacks, checks, material imbalance, material on board |
+| [Chessiverse personality test](https://chessiverse.com/chess-personality) | ~51 metrics, normalized vs population | Opening breadth, middlegame complexity, capture timing, endgame symmetry vs asymmetry |
+| [Data-Driven Chess Typology](https://www.diva-portal.org/smash/get/diva2:1977201/FULLTEXT01.pdf) | Feature engineering + ML (Activist / Theorist / Reflector / Pragmatist) | Phase distribution, castling timing, material volatility, mobility, king safety, sacrifices |
+| [Larry Kaufman — material imbalances](https://www.chess.com/article/view/the-evaluation-of-material-imbalances-by-im-larry-kaufman) | Engine-tested piece values | Bishop pair (~½ pawn), bishop ≈ knight when unpaired — motivates bishop-pair retention metrics |
+
+**ChessAnalyser alignment:** The project deliberately avoids engine evaluation on the hot path (see PLAN §12.4). Style metrics here measure **move and position patterns** from `GameMove`, `GamePositionSummary`, and `Game` — the same class of signals ChessBase and jk_182 use before bringing in ACPL or sharpness scores.
+
+---
+
+## 3. Style dimensions and data sources
+
+| Dimension | What it captures | Primary tables in ChessAnalyser |
+|-----------|------------------|--------------------------------|
+| **King safety / tempo** | When and how the king is sheltered | `GameMove` (castling flags, king moves) |
+| **Complexity vs simplicity** | Material on board, volatility of balance | `GamePositionSummary` |
+| **Piece philosophy** | Bishops vs knights, bishop pair | `GamePositionSummary` |
+| **Queen behaviour** | Early queen activity, queen trades | `GameMove`, `GamePositionSummary` |
+| **Spatial aggression** | Centre and forward play | `GameMove` (`ToSquare`) |
+| **Exchange temperament** | Captures, promotions | `GameMove` |
+| **Game shape** | Length, draws, decisiveness | `Game`, ply counts from summaries |
+| **Repertoire** | Opening breadth and concentration | `Game.Eco` |
+
+**Not available without schema or engine extensions:** checks (`IsCheck`), legal-move mobility, pawn-structure motifs (isolated/doubled/passers), sacrifice detection, ACPL, position sharpness/WDL.
+
+---
+
+## 4. Metric catalogue (planned)
+
+Full implementation specs live in [PLAN.md §12.6](./PLAN.md). Summary by phase:
+
+### Phase 1 — highest signal / lowest effort (implemented)
+
+| Key | Style signal |
+|-----|----------------|
+| `AverageCastlingPly` | Early castle ≈ pragmatic/safe; late or never ≈ riskier |
+| `AverageMaterialVolatility` | Std dev of material balance across a game — dynamic vs stable play |
+
+### Phase 2 — piece philosophy (implemented)
+
+| Key | Style signal |
+|-----|----------------|
+| `BishopPairFrequency` | Retaining both bishops — positional / long-diagonal preference |
+| `MinorPieceComposition` | Avg bishops − knights on player's side in a ply window (default plies 15–30) |
+
+### Phase 3 — exchange temperament
+
+| Key | Style signal |
+|-----|----------------|
+| `CaptureRate` | Captures per move — tactical exchanger |
+| `QueenTradeRate` | Queens exchanged before a ply threshold — simplifier vs attacker |
+
+### Phase 4 — spatial aggression
+
+| Key | Style signal |
+|-----|----------------|
+| `CentreMoveRate` | Moves to central squares |
+| `ForwardMoveRate` | Moves landing in opponent's half |
+
+### Phase 5 — king safety extensions
+
+| Key | Style signal |
+|-----|----------------|
+| `CastlingSidePreference` | Kingside vs queenside share |
+| `OppositeSideCastlingRate` | Both players castle to different wings |
+| `UncastledKingRate` | Games where player never castles |
+
+### Phase 6 — queen timing
+
+| Key | Style signal |
+|-----|----------------|
+| `FirstQueenMovePly` | Normalized ply of first queen move |
+
+### Phase 7 — game shape
+
+| Key | Style signal |
+|-----|----------------|
+| `AverageGameLength` | Mean plies per game |
+| `ShortDrawRate` | Short draws as share of all draws (fighting spirit proxy) |
+
+### Phase 8 — repertoire
+
+| Key | Style signal |
+|-----|----------------|
+| `EcoDiversity` | Distinct ECO codes per player |
+| `EcoConcentration` | Share of games in top-N ECO families |
+
+### Phase 9 — materialization extensions (later)
+
+| Extension | Enables |
+|-----------|---------|
+| `IsCheck` on `GameMove` | Check frequency |
+| `Phase` on `GamePositionSummary` | Opening/middlegame/endgame share |
+| `PlayerStyleProfile` composite metric | Normalized vector for comparison / future PCA |
+
+---
+
+## 5. Style profiles (metric combinations)
+
+Single metrics are weak; literature consistently combines them. Example **exploratory profiles** (run several metrics for the same player filter and compare):
+
+**Aggression / activist**
+
+- Low `AverageCastlingPly` or high `OppositeSideCastlingRate`
+- High `ForwardMoveRate`, `CentreMoveRate`, `CaptureRate`
+- Low `QueenTradeRate`
+- High `MaterialVolatility`
+
+**Positional / reflector**
+
+- High `BishopPairFrequency`
+- Moderate `PawnMoveRatio` (future) with long `AverageGameLength`
+- Low `MaterialVolatility`
+- Late `FirstQueenMovePly`
+
+**Simplifier / technical**
+
+- Low average material at midgame (existing `AverageMaterialByPlayerAtMove`)
+- High `QueenTradeRate`, high `CaptureRate`
+- Long games, high promotion rate (future)
+
+**Risk-taker**
+
+- High `MaterialVolatility`, high `UncastledKingRate`
+- Asymmetric minor-piece endgames (future `BishopVsKnightEndgameRate`)
+- Sharp ECO concentration (future curated sharp-opening list)
+
+A future **`PlayerStyleProfile`** metric could return a small normalized vector; v1 is **multiple registered executors** compared manually or in the UI.
+
+---
+
+## 6. Interpretation caveats
+
+1. **Openings dominate early plies** — filter by ply window or exclude opening plies when comparing middlegame style.
+2. **Opponent and era** — strong opponents and modern preparation homogenize choices.
+3. **Sample size** — prefer ≥ 30–50 games per player for stable averages.
+4. **Correlation ≠ causation** — high capture rate may reflect sharp openings, not innate aggression.
+5. **No engine** — measures preferences and patterns, not objective soundness.
+
+---
+
+## 7. Validation approach
+
+When implementing a new style metric, sanity-check against players with well-known reputations (e.g. Tal vs Petrosian, Kasparov vs Karpov) using the same year and colour filters. Direction of difference matters more than absolute numbers.
+
+---
+
+*Update this file when literature review or metric definitions change. Tick implementation items in [PLAN.md §12.6](./PLAN.md).*

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -28,6 +28,14 @@ internal static class MetricCatalog
                 "Player result summary from each player's perspective: wins, losses, draws, unknown results, total games, and score.",
             "AverageMaterialByPlayerAtMove" =>
                 "Average material at a full move for Player A compared with Player B, or all players, with colour mode Any/White/Black.",
+            "AverageCastlingPly" =>
+                "Mean half-move of the filtered player's first castle; games where the player never castled are excluded from the average.",
+            "AverageMaterialVolatility" =>
+                "Mean per-game standard deviation of signed material balance from the player's perspective across all plies (optional ply window).",
+            "BishopPairFrequency" =>
+                "Mean per-game share of plies in a window where the player retains both bishops (default ply window 15–30).",
+            "MinorPieceComposition" =>
+                "Mean bishops minus knights on the player's side in a ply window; positive values favour bishops (default ply window 15–30).",
             _ => null
         };
     }
@@ -91,6 +99,35 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: moveNumber (defaults to 1; full move N maps to PlyIndex = N * 2 - 1).",
                 "Optional: minGameYear, maxGameYear, eco."
+            ],
+            "AverageCastlingPly" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Games where the player never castled are excluded from the average; see GamesWithCastling."
+            ],
+            "AverageMaterialVolatility" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: minPlyIndex, maxPlyIndex to restrict which plies contribute to each game's std dev."
+            ],
+            "BishopPairFrequency" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: minPlyIndex, maxPlyIndex (defaults to 15 and 30 when both omitted)."
+            ],
+            "MinorPieceComposition" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: minPlyIndex, maxPlyIndex (defaults to 15 and 30 when both omitted).",
+                "AverageMinorPieceDelta > 0 indicates a bishop-oriented minor-piece mix."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -90,6 +90,10 @@ builder.Services.AddScoped<IMetricExecutor, GameCountByResultExecutor>();
 builder.Services.AddScoped<IMetricExecutor, GameCountByPlayerExecutor>();
 builder.Services.AddScoped<IMetricExecutor, PlayerResultSummaryExecutor>();
 builder.Services.AddScoped<IMetricExecutor, AverageMaterialByPlayerAtMoveExecutor>();
+builder.Services.AddScoped<IMetricExecutor, AverageCastlingPlyExecutor>();
+builder.Services.AddScoped<IMetricExecutor, AverageMaterialVolatilityExecutor>();
+builder.Services.AddScoped<IMetricExecutor, BishopPairFrequencyExecutor>();
+builder.Services.AddScoped<IMetricExecutor, MinorPieceCompositionExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/AnalyticsQuery.cs
+++ b/src/Interfaces/Analytics/AnalyticsQuery.cs
@@ -41,4 +41,14 @@ public sealed class AnalyticsQuery
     /// When null, the executor uses ply <c>4</c> (PLAN §5.3.4).
     /// </summary>
     public int? SummaryPlyIndex { get; init; }
+
+    /// <summary>
+    /// Inclusive lower bound on <c>GamePositionSummary.PlyIndex</c> for position-based style metrics.
+    /// </summary>
+    public int? MinPlyIndex { get; init; }
+
+    /// <summary>
+    /// Inclusive upper bound on <c>GamePositionSummary.PlyIndex</c> for position-based style metrics.
+    /// </summary>
+    public int? MaxPlyIndex { get; init; }
 }

--- a/src/Interfaces/Analytics/AverageCastlingPlyRow.cs
+++ b/src/Interfaces/Analytics/AverageCastlingPlyRow.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.Analytics;
+
+public sealed class AverageCastlingPlyRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GamesWithCastling { get; init; }
+
+    public double? AverageCastlingPly { get; init; }
+}

--- a/src/Interfaces/Analytics/AverageMaterialVolatilityRow.cs
+++ b/src/Interfaces/Analytics/AverageMaterialVolatilityRow.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.Analytics;
+
+public sealed class AverageMaterialVolatilityRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? AverageMaterialVolatility { get; init; }
+}

--- a/src/Interfaces/Analytics/BishopPairFrequencyRow.cs
+++ b/src/Interfaces/Analytics/BishopPairFrequencyRow.cs
@@ -1,0 +1,16 @@
+namespace Interfaces.Analytics;
+
+public sealed class BishopPairFrequencyRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? AverageBishopPairFrequency { get; init; }
+
+    public int? MinPlyIndex { get; init; }
+
+    public int? MaxPlyIndex { get; init; }
+}

--- a/src/Interfaces/Analytics/MinorPieceCompositionRow.cs
+++ b/src/Interfaces/Analytics/MinorPieceCompositionRow.cs
@@ -1,0 +1,16 @@
+namespace Interfaces.Analytics;
+
+public sealed class MinorPieceCompositionRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? AverageMinorPieceDelta { get; init; }
+
+    public int? MinPlyIndex { get; init; }
+
+    public int? MaxPlyIndex { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -125,6 +125,38 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Mean first-castling ply for a filtered player (games without castling excluded from the average).
+        /// </summary>
+        Task<IReadOnlyList<AverageCastlingPlyRow>> GetAverageCastlingPlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Mean per-game standard deviation of signed material balance for a filtered player.
+        /// </summary>
+        Task<IReadOnlyList<AverageMaterialVolatilityRow>> GetAverageMaterialVolatilityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Mean per-game share of plies where the filtered player retains both bishops in a ply window.
+        /// </summary>
+        Task<IReadOnlyList<BishopPairFrequencyRow>> GetBishopPairFrequencyAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Mean per-game average bishops-minus-knights for the filtered player in a ply window.
+        /// </summary>
+        Task<IReadOnlyList<MinorPieceCompositionRow>> GetMinorPieceCompositionAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -762,6 +794,112 @@ namespace Repositories
                         PlayerBSurname = NormalizeNonEmpty(query.PlayerBSurname),
                         PlayerBForenames = NormalizeNamePart(query.PlayerBForenames),
                         Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<AverageCastlingPlyRow>> GetAverageCastlingPlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<AverageCastlingPlyRow>(
+                new CommandDefinition(
+                    SqlStatements.GetAverageCastlingPly,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<AverageMaterialVolatilityRow>> GetAverageMaterialVolatilityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<AverageMaterialVolatilityRow>(
+                new CommandDefinition(
+                    SqlStatements.GetAverageMaterialVolatility,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = query.MinPlyIndex,
+                        MaxPlyIndex = query.MaxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<BishopPairFrequencyRow>> GetBishopPairFrequencyAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<BishopPairFrequencyRow>(
+                new CommandDefinition(
+                    SqlStatements.GetBishopPairFrequency,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = minPlyIndex,
+                        MaxPlyIndex = maxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<MinorPieceCompositionRow>> GetMinorPieceCompositionAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<MinorPieceCompositionRow>(
+                new CommandDefinition(
+                    SqlStatements.GetMinorPieceComposition,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = minPlyIndex,
+                        MaxPlyIndex = maxPlyIndex
                     },
                     cancellationToken: cancellationToken))).ToList();
 

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -406,6 +406,221 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Mean first-castling ply for a filtered player; games without castling are excluded from the average.
+        /// </summary>
+        public static string GetAverageCastlingPly =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            FirstCastle AS
+            (
+                SELECT fg.GameId, MIN(m.PlyIndex) AS CastlingPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                  AND m.MovingSide = fg.PlayerSide
+                GROUP BY fg.GameId
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GamesWithCastling,
+                   AVG(CAST(CastlingPly AS FLOAT)) AS AverageCastlingPly
+            FROM FirstCastle;
+            """;
+
+        /// <summary>
+        /// Mean per-game sample standard deviation of signed material balance from the player's perspective.
+        /// </summary>
+        public static string GetAverageMaterialVolatility =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            PerPlyBalance AS
+            (
+                SELECT fg.GameId,
+                       CASE fg.PlayerSide
+                           WHEN 'W' THEN CAST(s.WhiteMaterial - s.BlackMaterial AS FLOAT)
+                           WHEN 'B' THEN CAST(s.BlackMaterial - s.WhiteMaterial AS FLOAT)
+                       END AS SignedBalance
+                FROM FilteredGames fg
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND (@MinPlyIndex IS NULL OR s.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR s.PlyIndex <= @MaxPlyIndex)
+            ),
+            PerGameVolatility AS
+            (
+                SELECT GameId, STDEV(SignedBalance) AS MaterialVolatility
+                FROM PerPlyBalance
+                GROUP BY GameId
+                HAVING COUNT(*) >= 2
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(MaterialVolatility) AS AverageMaterialVolatility
+            FROM PerGameVolatility;
+            """;
+
+        /// <summary>
+        /// Mean per-game share of plies in a window where the filtered player has both bishops.
+        /// </summary>
+        public static string GetBishopPairFrequency =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            PerPly AS
+            (
+                SELECT fg.GameId,
+                       CASE
+                           WHEN fg.PlayerSide = 'W' AND s.WhiteBishopCount = 2 THEN 1.0
+                           WHEN fg.PlayerSide = 'B' AND s.BlackBishopCount = 2 THEN 1.0
+                           ELSE 0.0
+                       END AS HasBishopPair
+                FROM FilteredGames fg
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND (@MinPlyIndex IS NULL OR s.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR s.PlyIndex <= @MaxPlyIndex)
+            ),
+            PerGame AS
+            (
+                SELECT GameId, AVG(HasBishopPair) AS BishopPairFrequency
+                FROM PerPly
+                GROUP BY GameId
+                HAVING COUNT(*) > 0
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(BishopPairFrequency) AS AverageBishopPairFrequency,
+                   @MinPlyIndex AS MinPlyIndex,
+                   @MaxPlyIndex AS MaxPlyIndex
+            FROM PerGame;
+            """;
+
+        /// <summary>
+        /// Mean per-game average of bishops minus knights on the filtered player's side in a ply window.
+        /// </summary>
+        public static string GetMinorPieceComposition =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            PerPly AS
+            (
+                SELECT fg.GameId,
+                       CASE fg.PlayerSide
+                           WHEN 'W' THEN CAST(s.WhiteBishopCount - s.WhiteKnightCount AS FLOAT)
+                           WHEN 'B' THEN CAST(s.BlackBishopCount - s.BlackKnightCount AS FLOAT)
+                       END AS MinorPieceDelta
+                FROM FilteredGames fg
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND (@MinPlyIndex IS NULL OR s.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR s.PlyIndex <= @MaxPlyIndex)
+            ),
+            PerGame AS
+            (
+                SELECT GameId, AVG(MinorPieceDelta) AS AvgMinorPieceDelta
+                FROM PerPly
+                GROUP BY GameId
+                HAVING COUNT(*) > 0
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(AvgMinorPieceDelta) AS AverageMinorPieceDelta,
+                   @MinPlyIndex AS MinPlyIndex,
+                   @MaxPlyIndex AS MaxPlyIndex
+            FROM PerGame;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/AverageCastlingPlyExecutor.cs
+++ b/src/Services/Analytics/AverageCastlingPlyExecutor.cs
@@ -1,0 +1,42 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean half-move of the filtered player's first castle (PLAN §12.6 Phase 1).
+/// </summary>
+public sealed class AverageCastlingPlyExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "AverageCastlingPly";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetAverageCastlingPlyAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(AverageCastlingPlyRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GamesWithCastling,
+                r.AverageCastlingPly
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GamesWithCastling", "AverageCastlingPly"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(AverageCastlingPlyRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/AverageMaterialVolatilityExecutor.cs
+++ b/src/Services/Analytics/AverageMaterialVolatilityExecutor.cs
@@ -1,0 +1,42 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean per-game standard deviation of signed material balance (PLAN §12.6 Phase 1).
+/// </summary>
+public sealed class AverageMaterialVolatilityExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "AverageMaterialVolatility";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetAverageMaterialVolatilityAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(AverageMaterialVolatilityRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GameCount,
+                r.AverageMaterialVolatility
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GameCount", "AverageMaterialVolatility"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(AverageMaterialVolatilityRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/BishopPairFrequencyExecutor.cs
+++ b/src/Services/Analytics/BishopPairFrequencyExecutor.cs
@@ -1,0 +1,45 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean share of plies in a window where the player retains both bishops (PLAN §12.6 Phase 2).
+/// </summary>
+public sealed class BishopPairFrequencyExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "BishopPairFrequency";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var (minPly, maxPly) = PlayerStylePlyWindow.Resolve(query);
+        var rows = await _repository.GetBishopPairFrequencyAsync(query, minPly, maxPly, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(BishopPairFrequencyRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GameCount,
+                r.AverageBishopPairFrequency,
+                r.MinPlyIndex,
+                r.MaxPlyIndex
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GameCount", "AverageBishopPairFrequency", "MinPlyIndex", "MaxPlyIndex"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(BishopPairFrequencyRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -77,6 +77,26 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         string colourMode,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerMaterialAverageRow>>();
 
+    public Task<IReadOnlyList<AverageCastlingPlyRow>> GetAverageCastlingPlyAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<AverageCastlingPlyRow>>();
+
+    public Task<IReadOnlyList<AverageMaterialVolatilityRow>> GetAverageMaterialVolatilityAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<AverageMaterialVolatilityRow>>();
+
+    public Task<IReadOnlyList<BishopPairFrequencyRow>> GetBishopPairFrequencyAsync(
+        AnalyticsQuery query,
+        int? minPlyIndex,
+        int? maxPlyIndex,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<BishopPairFrequencyRow>>();
+
+    public Task<IReadOnlyList<MinorPieceCompositionRow>> GetMinorPieceCompositionAsync(
+        AnalyticsQuery query,
+        int? minPlyIndex,
+        int? maxPlyIndex,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<MinorPieceCompositionRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/src/Services/Analytics/MinorPieceCompositionExecutor.cs
+++ b/src/Services/Analytics/MinorPieceCompositionExecutor.cs
@@ -1,0 +1,45 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean bishops-minus-knights count for a player across a ply window (PLAN §12.6 Phase 2).
+/// </summary>
+public sealed class MinorPieceCompositionExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "MinorPieceComposition";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var (minPly, maxPly) = PlayerStylePlyWindow.Resolve(query);
+        var rows = await _repository.GetMinorPieceCompositionAsync(query, minPly, maxPly, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(MinorPieceCompositionRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GameCount,
+                r.AverageMinorPieceDelta,
+                r.MinPlyIndex,
+                r.MaxPlyIndex
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GameCount", "AverageMinorPieceDelta", "MinPlyIndex", "MaxPlyIndex"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(MinorPieceCompositionRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/PlayerStyleMetricValidation.cs
+++ b/src/Services/Analytics/PlayerStyleMetricValidation.cs
@@ -1,0 +1,13 @@
+using Interfaces.Analytics;
+
+namespace Services.Analytics;
+
+internal static class PlayerStyleMetricValidation
+{
+    public static void RequirePlayerFilter(AnalyticsQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (string.IsNullOrWhiteSpace(query.PlayerSurname))
+            throw new ArgumentException("playerSurname is required for this style metric.", nameof(query));
+    }
+}

--- a/src/Services/Analytics/PlayerStylePlyWindow.cs
+++ b/src/Services/Analytics/PlayerStylePlyWindow.cs
@@ -1,0 +1,22 @@
+using Interfaces.Analytics;
+
+namespace Services.Analytics;
+
+internal static class PlayerStylePlyWindow
+{
+    public const int DefaultMinPlyIndex = 15;
+
+    public const int DefaultMaxPlyIndex = 30;
+
+    /// <summary>
+    /// Returns the ply window for position-based style metrics. When both bounds are unset, uses 15–30.
+    /// </summary>
+    public static (int? MinPlyIndex, int? MaxPlyIndex) Resolve(AnalyticsQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        if (query.MinPlyIndex is null && query.MaxPlyIndex is null)
+            return (DefaultMinPlyIndex, DefaultMaxPlyIndex);
+
+        return (query.MinPlyIndex, query.MaxPlyIndex);
+    }
+}

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -32,6 +32,14 @@ public class MetricRegistryAndExecutorsTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PlayerMaterialAverageRow>());
+        repo.Setup(r => r.GetAverageCastlingPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AverageCastlingPlyRow>());
+        repo.Setup(r => r.GetAverageMaterialVolatilityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AverageMaterialVolatilityRow>());
+        repo.Setup(r => r.GetBishopPairFrequencyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<BishopPairFrequencyRow>());
+        repo.Setup(r => r.GetMinorPieceCompositionAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<MinorPieceCompositionRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -42,7 +50,11 @@ public class MetricRegistryAndExecutorsTests
             new GameCountByResultExecutor(repo.Object),
             new GameCountByPlayerExecutor(repo.Object),
             new PlayerResultSummaryExecutor(repo.Object),
-            new AverageMaterialByPlayerAtMoveExecutor(repo.Object)
+            new AverageMaterialByPlayerAtMoveExecutor(repo.Object),
+            new AverageCastlingPlyExecutor(repo.Object),
+            new AverageMaterialVolatilityExecutor(repo.Object),
+            new BishopPairFrequencyExecutor(repo.Object),
+            new MinorPieceCompositionExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -53,7 +65,11 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("GameCountByPlayer", sut.MetricKeys);
         Assert.Contains("PlayerResultSummary", sut.MetricKeys);
         Assert.Contains("AverageMaterialByPlayerAtMove", sut.MetricKeys);
-        Assert.Equal(8, sut.MetricKeys.Count);
+        Assert.Contains("AverageCastlingPly", sut.MetricKeys);
+        Assert.Contains("AverageMaterialVolatility", sut.MetricKeys);
+        Assert.Contains("BishopPairFrequency", sut.MetricKeys);
+        Assert.Contains("MinorPieceComposition", sut.MetricKeys);
+        Assert.Equal(12, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -549,6 +565,231 @@ public class MetricRegistryAndExecutorsTests
     {
         var repo = new Mock<IChessRepository>();
         var sut = new AverageMaterialByPlayerAtMoveExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task AverageCastlingPlyExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageCastlingPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AverageCastlingPlyRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Petrosian",
+                    PlayerForenames = "Tigran",
+                    GamesWithCastling = 2,
+                    AverageCastlingPly = 8.0
+                }
+            });
+
+        var sut = new AverageCastlingPlyExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Petrosian",
+            PlayerForenames = "Tigran"
+        });
+
+        Assert.Equal(["Player", "GamesWithCastling", "AverageCastlingPly"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Petrosian, Tigran", result.Rows[0][0]);
+        Assert.Equal(2, result.Rows[0][1]);
+        Assert.Equal(8.0, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task AverageCastlingPlyExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new AverageCastlingPlyExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task AverageCastlingPlyExecutor_PassesFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageCastlingPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AverageCastlingPlyRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail",
+            PlayerColour = "White",
+            MinGameYear = 1960,
+            MaxGameYear = 1970,
+            Eco = "B90"
+        };
+        var sut = new AverageCastlingPlyExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetAverageCastlingPlyAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerSurname == "Tal"
+                && q.PlayerForenames == "Mikhail"
+                && q.PlayerColour == "White"
+                && q.MinGameYear == 1960
+                && q.MaxGameYear == 1970
+                && q.Eco == "B90"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AverageMaterialVolatilityExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageMaterialVolatilityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AverageMaterialVolatilityRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Tal",
+                    PlayerForenames = "Mikhail",
+                    GameCount = 3,
+                    AverageMaterialVolatility = 2.5
+                }
+            });
+
+        var sut = new AverageMaterialVolatilityExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail"
+        });
+
+        Assert.Equal(["Player", "GameCount", "AverageMaterialVolatility"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Tal, Mikhail", result.Rows[0][0]);
+        Assert.Equal(3, result.Rows[0][1]);
+        Assert.Equal(2.5, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task AverageMaterialVolatilityExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new AverageMaterialVolatilityExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task AverageMaterialVolatilityExecutor_PassesPlyWindowToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageMaterialVolatilityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AverageMaterialVolatilityRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly",
+            MinPlyIndex = 15,
+            MaxPlyIndex = 40
+        };
+        var sut = new AverageMaterialVolatilityExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetAverageMaterialVolatilityAsync(
+            It.Is<AnalyticsQuery>(q => q.MinPlyIndex == 15 && q.MaxPlyIndex == 40),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task BishopPairFrequencyExecutor_MapsRowAndUsesDefaultPlyWindow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetBishopPairFrequencyAsync(
+                It.IsAny<AnalyticsQuery>(),
+                15,
+                30,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BishopPairFrequencyRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GameCount = 5,
+                    AverageBishopPairFrequency = 0.42,
+                    MinPlyIndex = 15,
+                    MaxPlyIndex = 30
+                }
+            });
+
+        var sut = new BishopPairFrequencyExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly"
+        });
+
+        Assert.Equal(["Player", "GameCount", "AverageBishopPairFrequency", "MinPlyIndex", "MaxPlyIndex"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Karpov, Anatoly", result.Rows[0][0]);
+        Assert.Equal(0.42, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task BishopPairFrequencyExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new BishopPairFrequencyExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task MinorPieceCompositionExecutor_PassesCustomPlyWindow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetMinorPieceCompositionAsync(
+                It.IsAny<AnalyticsQuery>(),
+                20,
+                35,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MinorPieceCompositionRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Tal",
+                    PlayerForenames = "Mikhail",
+                    GameCount = 3,
+                    AverageMinorPieceDelta = -0.25,
+                    MinPlyIndex = 20,
+                    MaxPlyIndex = 35
+                }
+            });
+
+        var sut = new MinorPieceCompositionExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail",
+            MinPlyIndex = 20,
+            MaxPlyIndex = 35
+        });
+
+        Assert.Single(result.Rows);
+        Assert.Equal(-0.25, result.Rows[0][2]);
+        repo.Verify(r => r.GetMinorPieceCompositionAsync(
+            It.IsAny<AnalyticsQuery>(),
+            20,
+            35,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MinorPieceCompositionExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new MinorPieceCompositionExecutor(repo.Object);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
     }


### PR DESCRIPTION
## Summary

Adds the first batch of **playing-style metrics** — behavioural fingerprints derived from `GameMove` and `GamePositionSummary` without engine evaluation. This PR delivers four per-player metrics covering king-safety tempo, material volatility, bishop-pair retention, and minor-piece composition, plus the research/plan documentation that motivated them.

## Changes

### New metrics

| Metric key | What it measures |
|------------|------------------|
| `AverageCastlingPly` | Mean half-move of the player's first castle (games without castling excluded from the average) |
| `AverageMaterialVolatility` | Mean per-game std dev of signed material balance from the player's perspective |
| `BishopPairFrequency` | Mean share of plies (default window 15–30) where the player retains both bishops |
| `MinorPieceComposition` | Mean bishops − knights on the player's side in a ply window (positive = bishop-oriented) |

All four require `playerSurname` and support existing `AnalyticsQuery` filters (`playerForenames`, `playerColour`, year, ECO). Position-based metrics default to **ply 15–30** when `minPlyIndex` / `maxPlyIndex` are omitted.

### Implementation

- `IMetricExecutor` + repository SQL for each metric
- `AnalyticsQuery` extended with `MinPlyIndex` / `MaxPlyIndex`
- `PlayerStyleMetricValidation` and `PlayerStylePlyWindow` helpers
- Registered in DI; descriptions and parameter hints in `MetricCatalog`
- Executor unit tests (mocked repository)

### Documentation

- New `docs/STYLE_METRICS.md` — literature review, style dimensions, profile combinations, caveats
- `docs/PLAN.md` §12.6 — playing-style metrics backlog (Phases 1–2 marked complete)
- `docs/EXAMPLE_ANALYSES.md` — usage examples for all four metrics
- `docs/AGENT_CONTEXT.md` — updated next-step guidance

## How to test

```bash
dotnet test ChessAnalyser.sln