### PR TITLE
feat: add corpus benchmarks for AverageMaterialVolatility and UI controls

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (Phase 2 style metrics implemented: `BishopPairFrequency`, `MinorPieceComposition`.)
+**Last updated:** 2026-06-11 (corpus benchmark infrastructure + `AverageMaterialVolatility` benchmark implemented.)
 
 ---
 
@@ -12,8 +12,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 | File | Role |
 |------|------|
-| [DESIGN.md](./DESIGN.md) | Requirements and locked decisions (facts, dimensions, C# vs SQL, rollups, year rules). |
-| [PLAN.md](./PLAN.md) | Implementation plan; **§11** (closed) + **§12** (metrics HTTP API) + **§12.6** (playing-style metrics backlog). |
+| [DESIGN.md](./DESIGN.md) | Requirements and locked decisions; **§12** corpus benchmarks (F-11). |
+| [PLAN.md](./PLAN.md) | Implementation plan; **§12.7** (corpus benchmarks — next), **§12.6** (style metrics). |
 | [STYLE_METRICS.md](./STYLE_METRICS.md) | Style research, literature, metric catalogue, profile combinations, caveats. |
 | **AGENT_CONTEXT.md** (this file) | Current progress and **recommended next small step**. |
 
@@ -31,9 +31,12 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ## 3. Recommended next step (small slice)
 
-**Do next:** Implement **Phase 3** of [PLAN.md §12.6](./PLAN.md): `CaptureRate`, then `QueenTradeRate`.
+**Do next:** Finish [PLAN.md §12.7](./PLAN.md) steps 3–5 — add corpus benchmarks to
+`BishopPairFrequency`, `MinorPieceComposition`, and `AverageCastlingPly`.
 
-**Then:** Phase 4 (`CentreMoveRate`, `ForwardMoveRate`) per §12.6.
+**Then:** §12.6 Phase 3 (`CaptureRate`, `QueenTradeRate`) with benchmark support from day one.
+
+**Branch:** `feat/style-metrics-phase-3`
 
 **Do not prioritize yet:** Dedicated HTTP **auth / rate limits** for `AnalyticsMetricsController` — **out of scope** until there is a **deployment or network exposure** plan (then treat as blocking; update PLAN §12.1 / §13). Optional hygiene: bind the dev host to **localhost** only.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -42,6 +42,7 @@ The framework should make it **easy to add new metrics** and **efficient to run 
 | F-5 | **Grouping** | Support **GROUP BY** one or more dimensions (year, player, ECO bucket, decile of ply, etc.). |
 | F-6 | **Extensibility** | New statistic types should be addable **without** modifying unrelated metrics (plugin-like or registry pattern; see §6). |
 | F-7 | **Reproducibility** | Same inputs (DB snapshot + metric definition + parameters) → same outputs (deterministic implementation; document rounding if any). |
+| F-11 | **Corpus-relative benchmarks** | Per-player style metrics should optionally report **how a filtered player compares to other players in the same database slice** (same non-identity filters), not only a raw scalar. See §12. |
 
 ### 3.2 Data access and interfaces
 
@@ -161,7 +162,7 @@ Detailed interfaces belong in PLAN.md; this section captures the **design intent
 - Optional **“unknown year”** bucket if you later want visibility into games dropped from year reports.
 - **Playing-style metrics** (move/position fingerprints without engine evaluation): research in
   [STYLE_METRICS.md](./STYLE_METRICS.md); implementation sequence in [PLAN.md §12.6](./PLAN.md).
-  First targets: `AverageCastlingPly`, `MaterialVolatility`.
+- **Corpus benchmarks for style metrics:** design in §12; implementation in [PLAN.md §12.7](./PLAN.md).
 
 ---
 
@@ -181,6 +182,110 @@ Detailed interfaces belong in PLAN.md; this section captures the **design intent
 | §3 Functional | Task breakdown, libraries, migrations |
 | §4 NFR | Testing, indexing, performance tasks |
 | §8 Resolved decisions | Schema, jobs, executor boundaries |
+| §12 Corpus benchmarks | PLAN §12.7 |
+
+---
+
+## 12. Corpus-relative benchmarks (locked direction)
+
+### 12.1 Problem
+
+Raw per-player style scalars (e.g. `AverageMaterialVolatility = 1.34` for Fischer over 827 games)
+are **hard to interpret in isolation**. External tools (Chessiverse, ChessBase style reports, academic
+typology work) normalize player features against a **reference population** before presenting style
+labels or rankings.
+
+ChessAnalyser should do the same, but **honestly**: benchmarks are always **relative to the loaded
+corpus and active filters**, not universal chess history.
+
+### 12.2 What a benchmark is (and is not)
+
+| In scope | Out of scope |
+|----------|----------------|
+| **Corpus average** — mean of the same metric across eligible players in the DB slice | Fixed external GM norms (“Tal = 1.8 volatility”) |
+| **Delta from corpus** — subject value minus corpus average | Engine-based quality or ACPL |
+| **Percentile rank** — subject’s position in the corpus distribution (0–100) | Multi-tenant or cross-database normalization |
+| Same **non-identity** filters as the subject query (year, ECO, colour mode, ply window) | Benchmarks that ignore filter alignment |
+
+A benchmark answers: *“Compared with everyone else in **my** database under **these** filters, is
+this player high, low, or typical on this metric?”*
+
+### 12.3 Reference population (locked)
+
+1. Apply the metric’s **per-player** aggregation formula to **every player** who appears in games
+   matching the query’s **non-identity** filters (`minGameYear`, `maxGameYear`, `eco`, `playerColour`
+   when it narrows the game set, `minPlyIndex` / `maxPlyIndex`, etc.).
+2. **Exclude the subject player** from the corpus average and percentile calculation (leave-one-out
+   style) so self-inclusion does not bias the baseline when the subject has many games.
+3. Include only players with at least **`benchmarkMinGames`** appearances in the filtered slice
+   (default **30**; configurable on the query).
+4. The **subject row** is always returned when `playerSurname` is set, even if below
+   `benchmarkMinGames`; benchmark columns may be null with a documented reason when the corpus has
+   too few eligible players.
+
+### 12.4 Query contract (proposed)
+
+Extend **`AnalyticsQuery`** (PLAN §12.7):
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `includeCorpusBenchmark` | `bool?` | `false` for existing metrics until migrated; **`true` default for style metrics** once supported | When true, append benchmark columns. |
+| `benchmarkMinGames` | `int?` | `30` | Minimum games per player for inclusion in corpus distribution. |
+
+**Backward compatibility:** existing API consumers that omit `includeCorpusBenchmark` keep receiving
+today’s column set until they opt in (or until a documented migration window).
+
+### 12.5 Result shape (proposed)
+
+When `includeCorpusBenchmark = true`, append columns to the **single subject row** (not a second
+“All players” row — unlike `AverageMaterialByPlayerAtMove`, which uses explicit series rows):
+
+| Column | Meaning |
+|--------|---------|
+| `CorpusAverage` | Mean per-player metric value over eligible corpus players |
+| `DeltaFromCorpus` | Subject value − `CorpusAverage` |
+| `CorpusPercentile` | Percentile rank 0–100 within eligible corpus (higher = higher metric value) |
+| `CorpusEligiblePlayerCount` | Players with ≥ `benchmarkMinGames` in the slice |
+
+Keep the existing subject columns (`GameCount`, `AverageMaterialVolatility`, etc.) unchanged.
+
+**Rounding:** document in metric specs; suggest 2 decimal places for averages/deltas, 1 for
+percentile in presentation.
+
+### 12.6 Priority metrics
+
+Implement benchmarks **first** on metrics where raw units are opaque:
+
+1. `AverageMaterialVolatility` (proof of concept)
+2. `BishopPairFrequency`, `MinorPieceComposition`
+3. `AverageCastlingPly`
+
+New style metrics from PLAN §12.6 Phase 3 onward should ship **with** benchmark support when
+practical, using shared enrichment code.
+
+### 12.7 Architecture (sketch)
+
+- **Shared helper** (name flexible): given subject per-player value + SQL or repository method that
+  returns corpus distribution for the same metric definition and filters → compute
+  `CorpusAverage`, `DeltaFromCorpus`, `CorpusPercentile`.
+- Reuse the **per-player aggregation SQL** already used for the subject; wrap in an outer query or
+  C# pass over per-player rows — prefer one repository round-trip per metric where §8.5 allows.
+- **No new persisted tables** in v1; benchmarks are computed on read.
+- Optional v2: cache corpus aggregates per `(metricKey, filter hash)` if performance requires it.
+
+Pattern precedent: **`AverageMaterialByPlayerAtMove`** already compares Player A to an all-player
+baseline; corpus benchmarks generalize that idea for style metrics with percentile semantics.
+
+### 12.8 Interpretation and UI copy
+
+Documentation and `MetricCatalog` hints must state:
+
+- Percentiles are **corpus-local** (“78th percentile in this database with these filters”).
+- High/low is **not** good/bad — style fingerprint only.
+- Sparse corpora (few players or few games) produce unreliable benchmarks; surface
+  `CorpusEligiblePlayerCount`.
+
+See also [STYLE_METRICS.md §8](./STYLE_METRICS.md).
 
 ---
 

--- a/docs/EXAMPLE_ANALYSES.md
+++ b/docs/EXAMPLE_ANALYSES.md
@@ -747,26 +747,33 @@ Content-Type: application/json
 {
   "metricKey": "AverageMaterialVolatility",
   "query": {
-    "playerSurname": "Tal",
-    "playerForenames": "Mikhail",
+    "playerSurname": "Fischer",
+    "playerForenames": "Robert James",
     "playerColour": "Any",
-    "minPlyIndex": 15,
-    "maxPlyIndex": 40
+    "includeCorpusBenchmark": true,
+    "benchmarkMinGames": 30
   }
 }
 ```
 
 ### Result columns
 
-- `Player` — filtered player name
-- `GameCount` — games with at least two position summaries in the ply window (needed for std dev)
-- `AverageMaterialVolatility` — mean per-game sample standard deviation of signed material balance
-  from the player's perspective
+Without `includeCorpusBenchmark`:
+
+- `Player`, `GameCount`, `AverageMaterialVolatility`
+
+With `includeCorpusBenchmark: true` (also adds):
+
+- `CorpusAverage` — mean volatility of other eligible players in the same DB slice
+- `DeltaFromCorpus` — subject minus corpus average
+- `CorpusPercentile` — rank 0–100 among eligible corpus players
+- `CorpusEligiblePlayerCount` — players with at least `benchmarkMinGames` games
 
 ### Notes
 
 - Balance is `WhiteMaterial - BlackMaterial` when the player had White, reversed when Black.
 - Omit `minPlyIndex` / `maxPlyIndex` to include all plies (including ply `-1`).
+- Benchmarks are **corpus-local** — interpret percentiles relative to your loaded database.
 - Requires `dbo.GamePositionSummary` rows.
 
 ---

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,7 +1,7 @@
 # ChessAnalyser — Board-position analytics (PLAN)
 
 **Location:** **`docs/`** — alongside [DESIGN.md](./DESIGN.md) and [AGENT_CONTEXT.md](./AGENT_CONTEXT.md).  
-**Document status:** Stage 2 (design guide) + **Stage 3 complete** (§11 checklist, 2026-05-10) + **Stage 4 §12 checklist complete** (metrics HTTP API + DESIGN F-9 / Q7 alignment). **Active implementation direction:** §12.6 playing-style metrics (first: `AverageCastlingPly`, `MaterialVolatility`); HTTP auth **deferred** while the app stays local-only / undeployed.  
+**Document status:** Stage 2 (design guide) + **Stage 3 complete** (§11 checklist, 2026-05-10) + **Stage 4 §12 checklist complete** (metrics HTTP API + DESIGN F-9 / Q7 alignment). **Active implementation direction:** §12.7 corpus benchmarks for style metrics, then §12.6 Phase 3; HTTP auth **deferred** while the app stays local-only / undeployed.  
 **Authority:** Implements [DESIGN.md](./DESIGN.md). Update this plan when scope or decisions change.
 
 ---
@@ -17,6 +17,7 @@
 | §8.5 C# domain logic; SQL for access / trivial aggregates | §5.4, §8 |
 | F-9 / Q7 (programmatic access) | §12 (Stage 4 — HTTP surface for existing registry) |
 | Playing-style metrics (research) | [STYLE_METRICS.md](./STYLE_METRICS.md); implementation §12.6 |
+| Corpus benchmarks (F-11) | [DESIGN.md §12](./DESIGN.md); implementation §12.7 |
 
 ---
 
@@ -298,9 +299,11 @@ Items **1–13** are **complete** in source for the board-position analytics gro
    `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`,
    `PlayerResultSummary`).
 3. [x] **Improve discovery** — descriptions and parameter hints on `GET /api/analytics/metrics`.
-4. **Playing-style metrics** — follow **[§12.6](./PLAN.md)** in order: first `AverageCastlingPly`,
-   then `MaterialVolatility`, then Phases 2–8. Research background: [STYLE_METRICS.md](./STYLE_METRICS.md).
-5. **Tests** — per-metric executor tests with mocked **`IChessRepository`** (and API smoke tests for
+4. [x] **Playing-style metrics Phases 1–2** — `AverageCastlingPly`, `AverageMaterialVolatility`,
+   `BishopPairFrequency`, `MinorPieceComposition` (see §12.6).
+5. **Corpus benchmarks** — **[§12.7](./PLAN.md)** before §12.6 Phase 3; design [DESIGN.md §12](./DESIGN.md).
+6. **Playing-style metrics Phase 3+** — `CaptureRate`, `QueenTradeRate`, … per §12.6 after benchmarks v1.
+7. **Tests** — per-metric executor tests with mocked **`IChessRepository`** (and API smoke tests for
    new keys), following §12.3.
 
 **Optional:** Record a fresh materialization throughput line in [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) when you change hot paths in the deriver or summary factory.
@@ -595,6 +598,97 @@ sound sacrifice detection — see [STYLE_METRICS.md §4 Phase 9](./STYLE_METRICS
 Petrosian) on `AverageCastlingPly` and `MaterialVolatility` with the same filters; see
 [STYLE_METRICS.md §7](./STYLE_METRICS.md).
 
+**Benchmark dependency:** Phase 3+ metrics should use the shared benchmark enrichment from §12.7
+when `includeCorpusBenchmark` is supported, rather than adding more raw-only scalars.
+
+---
+
+### 12.7 Corpus benchmarks for style metrics (implement before §12.6 Phase 3)
+
+**Decision (2026):** Raw style scalars (e.g. Fischer `AverageMaterialVolatility ≈ 1.34`) are weakly
+informative without a **corpus-relative** reference. Implement optional benchmark columns per
+[DESIGN.md §12](./DESIGN.md) before adding Phase 3 style metrics.
+
+**Goals:**
+
+- Same metric definition and **non-identity** filters for subject and corpus.
+- Subject excluded from corpus mean and percentile (leave-one-out).
+- Opt-in via `includeCorpusBenchmark`; default **`false`** until callers migrate (document in
+  `MetricCatalog` when style metrics flip default to `true`).
+
+#### 12.7.1 Query extensions
+
+Add to **`AnalyticsQuery`** (`Interfaces/Analytics/AnalyticsQuery.cs`):
+
+| Field | Type | Default when null |
+|-------|------|-----------------|
+| `IncludeCorpusBenchmark` | `bool?` | `false` |
+| `BenchmarkMinGames` | `int?` | `30` |
+
+Expose in HTTP JSON as `includeCorpusBenchmark`, `benchmarkMinGames`. UI: optional checkbox on style
+metrics section (follow-up after API).
+
+#### 12.7.2 Shared components
+
+1. [ ] **`CorpusBenchmarkResult`** (or fields on existing row DTOs) — `CorpusAverage`,
+   `DeltaFromCorpus`, `CorpusPercentile`, `CorpusEligiblePlayerCount` (all nullable when benchmark
+   not requested or corpus too small).
+2. [ ] **`ICorpusBenchmarkCalculator`** (pure C#) — inputs: subject value, read-only list of
+   `(playerId or name, perPlayerValue, gameCount)` for eligible corpus players → outputs benchmark
+   fields. Unit-test percentile edge cases (ties, n=1, subject at min/max).
+3. [ ] **Repository pattern** — per metric, either:
+   - **(Preferred)** one SQL statement returning subject row + corpus distribution via CTEs
+     (`PerPlayerMetric` → `CorpusStats`), or
+   - two reads: subject aggregate + all per-player aggregates (acceptable for v1 if SQL complexity
+     is high).
+
+Document chosen approach in code remarks per metric.
+
+**Corpus eligibility rule:** player appears in ≥ `benchmarkMinGames` games in the filtered game set
+(same rule as DESIGN §12.3).
+
+**Percentile:** `PERCENT_RANK`-style over eligible per-player values (0–100 scale); document tie
+handling in tests.
+
+#### 12.7.3 Implementation sequence (PR-sized)
+
+1. [x] **Infrastructure PR** — `AnalyticsQuery` fields, `ICorpusBenchmarkCalculator` + tests, row
+   DTO optional benchmark fields.
+2. [x] **`AverageMaterialVolatility` + benchmark** — proof of concept; extend executor columns when
+   `includeCorpusBenchmark = true`; per-player repository SQL + calculator; update `MetricCatalog` and
+   [EXAMPLE_ANALYSES.md](./EXAMPLE_ANALYSES.md).
+3. [ ] **`BishopPairFrequency` + benchmark** — reuse shared calculator / SQL pattern.
+4. [ ] **`MinorPieceComposition` + benchmark**
+5. [ ] **`AverageCastlingPly` + benchmark**
+6. [ ] **Docs pass** — [STYLE_METRICS.md](./STYLE_METRICS.md) §8, `AGENT_CONTEXT.md`, example
+   showing Fischer row with corpus columns.
+
+**Result columns when benchmark enabled** (append to existing subject row):
+
+- `CorpusAverage`
+- `DeltaFromCorpus`
+- `CorpusPercentile`
+- `CorpusEligiblePlayerCount`
+
+#### 12.7.4 Testing
+
+| Layer | Tests |
+|-------|--------|
+| `CorpusBenchmarkCalculator` | Empty corpus; single player; ties; subject excluded from mean; percentile boundaries |
+| Executor | Mock repository returning subject + corpus rows; assert columns present only when flag set |
+| Integration (optional) | Small fixture DB: two players, known ordering, assert percentile |
+
+**Manual validation:** Run `AverageMaterialVolatility` for Fischer with `includeCorpusBenchmark:
+true` — confirm `CorpusPercentile` and `DeltaFromCorpus` move in sensible direction vs a second
+player (e.g. Petrosian) on the same filters.
+
+#### 12.7.5 Non-goals (v1)
+
+- Persisted benchmark cache tables
+- External reference-player presets (user compares by running two queries or future `playerB` filter)
+- Benchmarks on non-style metrics (`GameCountByEco`, etc.)
+- Default `includeCorpusBenchmark: true` until Phase 3 metrics exist (optional follow-up)
+
 ---
 
 ## 13. Risks and mitigations
@@ -605,6 +699,7 @@ Petrosian) on `AverageCastlingPly` and `MaterialVolatility` with the same filter
 | Large DB backfill time | Process game-by-game; optional parallelism with cap. |
 | Transaction size for huge games | Batch inserts inside per-game transaction or chunk by N plies (rare games > 500 plies). |
 | Unauthenticated metrics HTTP endpoint | **Accepted for local-only solo use** (see §12.1, §12.4). Before **deployment or network exposure**, add rate limits, auth, or strict network restriction and document the chosen approach. |
+| Misleading benchmark percentiles on tiny corpora | Require `benchmarkMinGames`; return `CorpusEligiblePlayerCount`; document corpus-local interpretation (DESIGN §12.8). |
 
 ---
 
@@ -618,4 +713,4 @@ Petrosian) on `AverageCastlingPly` and `MaterialVolatility` with the same filter
 
 ---
 
-*End of PLAN.md. Stage 3 (§11) is complete; Stage 4 **§12** is complete. **Active backlog:** §12.6 playing-style metrics (start with `AverageCastlingPly`, `MaterialVolatility`); §12.4 for general UI/tests; §12.5 player material comparison is complete.*
+*End of PLAN.md. Stage 3 (§11) is complete; Stage 4 **§12** is complete. **Active backlog:** §12.7 corpus benchmarks, then §12.6 Phase 3; §12.5 player material comparison is complete.*

--- a/docs/STYLE_METRICS.md
+++ b/docs/STYLE_METRICS.md
@@ -2,7 +2,7 @@
 
 **Location:** `docs/` alongside [DESIGN.md](./DESIGN.md), [PLAN.md](./PLAN.md), and [EXAMPLE_ANALYSES.md](./EXAMPLE_ANALYSES.md).  
 **Purpose:** Capture how chess playing style is assessed in the literature and tools, what ChessAnalyser can measure **without an engine**, and how individual metrics combine into interpretable profiles.  
-**Implementation backlog:** [PLAN.md §12.6](./PLAN.md) (ordered PR sequence).
+**Implementation backlog:** [PLAN.md §12.7](./PLAN.md) (corpus benchmarks), then [PLAN.md §12.6](./PLAN.md) Phase 3+.
 
 ---
 
@@ -14,6 +14,7 @@ Playing style is not a single scalar. Analysts and researchers use **many behavi
 - Prefer **middlegame windows** (e.g. plies 15–40) when opening noise should be reduced.
 - Require **sufficient sample size** (dozens of games; literature often excludes short draws and out-of-prime years).
 - Be read as **choices**, not **quality** — without engine evaluation, high capture rate does not distinguish Tal from a blunderer.
+- Prefer **corpus-relative** readings (percentile vs your loaded database) over isolated scalars — see §8 and [DESIGN.md §12](./DESIGN.md).
 
 ---
 
@@ -168,4 +169,33 @@ When implementing a new style metric, sanity-check against players with well-kno
 
 ---
 
-*Update this file when literature review or metric definitions change. Tick implementation items in [PLAN.md §12.6](./PLAN.md).*
+## 8. Corpus benchmarks (interpretation)
+
+Raw values like `AverageMaterialVolatility = 1.34` are **not self-explanatory**. ChessAnalyser is
+adding **corpus-relative benchmarks** ([DESIGN.md §12](./DESIGN.md), [PLAN.md §12.7](./PLAN.md)):
+
+| Column | Meaning |
+|--------|---------|
+| `CorpusAverage` | Mean of the same metric across other eligible players in your DB (same filters) |
+| `DeltaFromCorpus` | Subject minus corpus average |
+| `CorpusPercentile` | Where the subject ranks 0–100 among eligible players (higher = higher metric value) |
+| `CorpusEligiblePlayerCount` | How many players met the minimum game threshold |
+
+**How to read a row**
+
+> Fischer: volatility 1.34, corpus avg 1.08, delta +0.26, 78th percentile  
+> → More material swing than most players **in this database** under the chosen filters.
+
+**Caveats**
+
+- Benchmarks are **corpus-local**, not universal chess truth.
+- Requires enough players and games (`benchmarkMinGames`, default 30).
+- Subject is **excluded** from the corpus mean so large game counts do not dominate the baseline.
+- Opt in with `includeCorpusBenchmark: true` on the metric query until defaults change.
+
+Phase 3+ style metrics should ship with benchmark support where possible so new scalars are not
+published without context.
+
+---
+
+*Update this file when literature review or metric definitions change. Tick implementation items in [PLAN.md §12.6](./PLAN.md) and [PLAN.md §12.7](./PLAN.md).*

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -112,7 +112,9 @@ internal static class MetricCatalog
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional: minPlyIndex, maxPlyIndex to restrict which plies contribute to each game's std dev."
+                "Optional: minPlyIndex, maxPlyIndex to restrict which plies contribute to each game's std dev.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "BishopPairFrequency" =>
             [

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -82,6 +82,7 @@ builder.Services.AddSingleton<IPieceValues, ClassicalPieceValues>();
 builder.Services.AddScoped<IGamePositionSummaryFactory, GamePositionSummaryFactory>();
 builder.Services.AddScoped<IGameMoveDeriver, GameMoveDeriver>();
 builder.Services.AddScoped<IAnalyticsMaterializationService, AnalyticsMaterializationService>();
+builder.Services.AddSingleton<ICorpusBenchmarkCalculator, CorpusBenchmarkCalculator>();
 builder.Services.AddScoped<IMetricExecutor, AverageMaterialByYearAndColourExecutor>();
 builder.Services.AddScoped<IMetricExecutor, KnightMoveDestinationFrequencyExecutor>();
 builder.Services.AddScoped<IMetricExecutor, GameCountByEcoExecutor>();

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -143,6 +143,13 @@
         <label>moveNumber <input type="number" id="qMoveNumber" value="1" min="1" step="1" /></label>
       </div>
     </div>
+    <div id="corpusBenchmarkFields" class="metric-fields" hidden>
+      <p class="hint">Corpus benchmark compares the selected player to other eligible players in this database using the same year, ECO, and colour filters. Percentiles are corpus-local, not universal chess history.</p>
+      <div class="row">
+        <label><input type="checkbox" id="qIncludeCorpusBenchmark" /> Include corpus benchmark</label>
+        <label>benchmarkMinGames <input type="number" id="qBenchmarkMinGames" placeholder="default 30" min="1" step="1" /></label>
+      </div>
+    </div>
     <button type="button" id="runMetric">Run metric</button>
     <div class="status" id="metricStatus"></div>
     <div id="metricTableWrap"></div>
@@ -389,22 +396,35 @@
       var metricPlayerFilters = document.getElementById('metricPlayerFilters');
       var sideMaterialFields = document.getElementById('sideMaterialFields');
       var playerComparisonFields = document.getElementById('playerComparisonFields');
+      var corpusBenchmarkFields = document.getElementById('corpusBenchmarkFields');
+
+      var CORPUS_BENCHMARK_METRICS = {
+        AverageMaterialVolatility: true
+      };
 
       function selectedMetricKey() {
         return (metricKeySel.value || '').trim();
+      }
+
+      function supportsCorpusBenchmark(key) {
+        return !!CORPUS_BENCHMARK_METRICS[key];
       }
 
       function updateMetricFields() {
         var key = selectedMetricKey();
         var isPlayerComparison = key === 'AverageMaterialByPlayerAtMove';
         var isSideMaterial = key === 'AverageMaterialByYearAndColour';
+        var isCorpusBenchmark = supportsCorpusBenchmark(key);
 
         playerComparisonFields.hidden = !isPlayerComparison;
         sideMaterialFields.hidden = !isSideMaterial;
         metricPlayerFilters.hidden = isPlayerComparison;
+        corpusBenchmarkFields.hidden = !isCorpusBenchmark;
 
         if (isPlayerComparison)
           metricStatus.textContent = 'Select Player A, optionally Player B, then choose colour and full move number.';
+        else if (isCorpusBenchmark)
+          metricStatus.textContent = 'Select a player, then optionally enable corpus benchmark to add percentile columns.';
         else
           metricStatus.textContent = '';
         metricStatus.className = 'status';
@@ -449,6 +469,14 @@
 
         if (eco != null) q.eco = eco;
         if (key === 'AverageMaterialByYearAndColour' && ply != null) q.summaryPlyIndex = ply;
+
+        if (supportsCorpusBenchmark(key)) {
+          if (document.getElementById('qIncludeCorpusBenchmark').checked)
+            q.includeCorpusBenchmark = true;
+          var benchmarkMinGames = numVal('qBenchmarkMinGames');
+          if (benchmarkMinGames != null) q.benchmarkMinGames = benchmarkMinGames;
+        }
+
         return Object.keys(q).length ? q : undefined;
       }
 

--- a/src/Interfaces/Analytics/AnalyticsQuery.cs
+++ b/src/Interfaces/Analytics/AnalyticsQuery.cs
@@ -51,4 +51,14 @@ public sealed class AnalyticsQuery
     /// Inclusive upper bound on <c>GamePositionSummary.PlyIndex</c> for position-based style metrics.
     /// </summary>
     public int? MaxPlyIndex { get; init; }
+
+    /// <summary>
+    /// When true, eligible style metrics append corpus benchmark columns (DESIGN §12).
+    /// </summary>
+    public bool? IncludeCorpusBenchmark { get; init; }
+
+    /// <summary>
+    /// Minimum games per player for corpus benchmark eligibility (default 30).
+    /// </summary>
+    public int? BenchmarkMinGames { get; init; }
 }

--- a/src/Interfaces/Analytics/AverageMaterialVolatilityRow.cs
+++ b/src/Interfaces/Analytics/AverageMaterialVolatilityRow.cs
@@ -9,4 +9,12 @@ public sealed class AverageMaterialVolatilityRow
     public int GameCount { get; init; }
 
     public double? AverageMaterialVolatility { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Interfaces/Analytics/CorpusBenchmarkResult.cs
+++ b/src/Interfaces/Analytics/CorpusBenchmarkResult.cs
@@ -1,0 +1,15 @@
+namespace Interfaces.Analytics;
+
+/// <summary>
+/// Corpus-relative benchmark columns (DESIGN §12, PLAN §12.7).
+/// </summary>
+public sealed class CorpusBenchmarkResult
+{
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
+}

--- a/src/Interfaces/Analytics/ICorpusBenchmarkCalculator.cs
+++ b/src/Interfaces/Analytics/ICorpusBenchmarkCalculator.cs
@@ -1,0 +1,14 @@
+namespace Interfaces.Analytics;
+
+/// <summary>
+/// Computes corpus-relative benchmark fields from per-player metric aggregates (DESIGN §12).
+/// </summary>
+public interface ICorpusBenchmarkCalculator
+{
+    CorpusBenchmarkResult Compute(
+        double? subjectValue,
+        string subjectSurname,
+        string? subjectForenames,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayerRows,
+        int benchmarkMinGames);
+}

--- a/src/Interfaces/Analytics/PlayerStylePerPlayerMetricRow.cs
+++ b/src/Interfaces/Analytics/PlayerStylePerPlayerMetricRow.cs
@@ -1,0 +1,15 @@
+namespace Interfaces.Analytics;
+
+/// <summary>
+/// Per-player aggregate for corpus benchmark distributions.
+/// </summary>
+public sealed class PlayerStylePerPlayerMetricRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? MetricValue { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -139,6 +139,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player material volatility aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageMaterialVolatilityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Mean per-game share of plies where the filtered player retains both bishops in a ply window.
         /// </summary>
         Task<IReadOnlyList<BishopPairFrequencyRow>> GetBishopPairFrequencyAsync(
@@ -840,6 +847,30 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = query.MinPlyIndex,
+                        MaxPlyIndex = query.MaxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageMaterialVolatilityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerAverageMaterialVolatility,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco),
                         MinPlyIndex = query.MinPlyIndex,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -506,6 +506,78 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Per-player mean per-game material volatility for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerAverageMaterialVolatility =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       g.WhitePlayerId,
+                       g.BlackPlayerId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            PerPlyBalance AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       CASE a.PlayerSide
+                           WHEN 'W' THEN CAST(s.WhiteMaterial - s.BlackMaterial AS FLOAT)
+                           WHEN 'B' THEN CAST(s.BlackMaterial - s.WhiteMaterial AS FLOAT)
+                       END AS SignedBalance
+                FROM Appearances a
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = a.GameId
+                WHERE (@MinPlyIndex IS NULL OR s.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR s.PlyIndex <= @MaxPlyIndex)
+            ),
+            PerGameVolatility AS
+            (
+                SELECT PlayerSurname,
+                       PlayerForenames,
+                       GameId,
+                       STDEV(SignedBalance) AS MaterialVolatility
+                FROM PerPlyBalance
+                GROUP BY PlayerSurname, PlayerForenames, GameId
+                HAVING COUNT(*) >= 2
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(MaterialVolatility) AS MetricValue
+            FROM PerGameVolatility
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Mean per-game share of plies in a window where the filtered player has both bishops.
         /// </summary>
         public static string GetBishopPairFrequency =>

--- a/src/Services/Analytics/AverageMaterialVolatilityExecutor.cs
+++ b/src/Services/Analytics/AverageMaterialVolatilityExecutor.cs
@@ -6,30 +6,91 @@ namespace Services.Analytics;
 /// <summary>
 /// Mean per-game standard deviation of signed material balance (PLAN §12.6 Phase 1).
 /// </summary>
-public sealed class AverageMaterialVolatilityExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class AverageMaterialVolatilityExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "AverageMaterialVolatility";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetAverageMaterialVolatilityAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetAverageMaterialVolatilityAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(AverageMaterialVolatilityRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerAverageMaterialVolatilityAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ? ["Player", "GameCount", "AverageMaterialVolatility", "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"]
+                : ["Player", "GameCount", "AverageMaterialVolatility"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private AverageMaterialVolatilityRow EnrichWithBenchmark(
+        AverageMaterialVolatilityRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageMaterialVolatility,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new AverageMaterialVolatilityRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            AverageMaterialVolatility = row.AverageMaterialVolatility,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(AverageMaterialVolatilityRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GameCount,
                 r.AverageMaterialVolatility
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GameCount", "AverageMaterialVolatility"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.AverageMaterialVolatility,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(AverageMaterialVolatilityRow row)

--- a/src/Services/Analytics/CorpusBenchmarkCalculator.cs
+++ b/src/Services/Analytics/CorpusBenchmarkCalculator.cs
@@ -1,0 +1,75 @@
+using Interfaces.Analytics;
+
+namespace Services.Analytics;
+
+public sealed class CorpusBenchmarkCalculator : ICorpusBenchmarkCalculator
+{
+    public CorpusBenchmarkResult Compute(
+        double? subjectValue,
+        string subjectSurname,
+        string? subjectForenames,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayerRows,
+        int benchmarkMinGames)
+    {
+        ArgumentNullException.ThrowIfNull(subjectSurname);
+        ArgumentNullException.ThrowIfNull(perPlayerRows);
+
+        if (benchmarkMinGames < 1)
+            throw new ArgumentOutOfRangeException(nameof(benchmarkMinGames));
+
+        var eligible = perPlayerRows
+            .Where(r => r.GameCount >= benchmarkMinGames && r.MetricValue is not null)
+            .ToList();
+
+        var corpus = eligible
+            .Where(r => !PlayerIdentityMatches(r, subjectSurname, subjectForenames))
+            .Select(r => r.MetricValue!.Value)
+            .ToList();
+
+        if (corpus.Count == 0 || subjectValue is null)
+        {
+            return new CorpusBenchmarkResult
+            {
+                CorpusEligiblePlayerCount = corpus.Count
+            };
+        }
+
+        var average = corpus.Average();
+        var percentile = ComputePercentile(subjectValue.Value, corpus);
+
+        return new CorpusBenchmarkResult
+        {
+            CorpusAverage = average,
+            DeltaFromCorpus = subjectValue.Value - average,
+            CorpusPercentile = percentile,
+            CorpusEligiblePlayerCount = corpus.Count
+        };
+    }
+
+    public static double ComputePercentile(double subjectValue, IReadOnlyList<double> corpusValues)
+    {
+        if (corpusValues.Count == 0)
+            throw new ArgumentException("Corpus must not be empty.", nameof(corpusValues));
+
+        if (subjectValue < corpusValues.Min())
+            return 0;
+
+        if (subjectValue > corpusValues.Max())
+            return 100;
+
+        var less = corpusValues.Count(v => v < subjectValue);
+        return 100.0 * less / corpusValues.Count;
+    }
+
+    private static bool PlayerIdentityMatches(
+        PlayerStylePerPlayerMetricRow row, string surname, string? forenames)
+    {
+        if (!string.Equals(row.PlayerSurname, surname, StringComparison.Ordinal))
+            return false;
+
+        if (forenames is null)
+            return true;
+
+        return string.Equals(row.PlayerForenames ?? string.Empty, forenames, StringComparison.Ordinal);
+    }
+}

--- a/src/Services/Analytics/CorpusBenchmarkQueryDefaults.cs
+++ b/src/Services/Analytics/CorpusBenchmarkQueryDefaults.cs
@@ -1,0 +1,14 @@
+using Interfaces.Analytics;
+
+namespace Services.Analytics;
+
+internal static class CorpusBenchmarkQueryDefaults
+{
+    public const int DefaultBenchmarkMinGames = 30;
+
+    public static bool IncludeCorpusBenchmark(AnalyticsQuery query) =>
+        query.IncludeCorpusBenchmark == true;
+
+    public static int BenchmarkMinGames(AnalyticsQuery query) =>
+        query.BenchmarkMinGames is > 0 ? query.BenchmarkMinGames.Value : DefaultBenchmarkMinGames;
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -85,6 +85,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<AverageMaterialVolatilityRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageMaterialVolatilityAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<BishopPairFrequencyRow>> GetBishopPairFrequencyAsync(
         AnalyticsQuery query,
         int? minPlyIndex,

--- a/test/ServicesTests/Analytics/CorpusBenchmarkCalculatorTests.cs
+++ b/test/ServicesTests/Analytics/CorpusBenchmarkCalculatorTests.cs
@@ -1,0 +1,78 @@
+using Interfaces.Analytics;
+using Services.Analytics;
+
+namespace ServicesTests.Analytics;
+
+public class CorpusBenchmarkCalculatorTests
+{
+    private readonly CorpusBenchmarkCalculator _sut = new();
+
+    [Fact]
+    public void Compute_ReturnsNullBenchmark_WhenCorpusEmpty()
+    {
+        var result = _sut.Compute(
+            1.5,
+            "Fischer",
+            "Robert James",
+            new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 50, MetricValue = 1.5 }
+            },
+            benchmarkMinGames: 30);
+
+        Assert.Null(result.CorpusAverage);
+        Assert.Null(result.DeltaFromCorpus);
+        Assert.Null(result.CorpusPercentile);
+        Assert.Equal(0, result.CorpusEligiblePlayerCount);
+    }
+
+    [Fact]
+    public void Compute_ExcludesSubjectFromCorpusAverage()
+    {
+        var result = _sut.Compute(
+            1.4,
+            "Fischer",
+            "Robert James",
+            new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 50, MetricValue = 1.4 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 40, MetricValue = 1.0 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 35, MetricValue = 1.8 }
+            },
+            benchmarkMinGames: 30);
+
+        Assert.Equal(1.4, result.CorpusAverage);
+        Assert.Equal(0, result.DeltaFromCorpus);
+        Assert.Equal(50, result.CorpusPercentile);
+        Assert.Equal(2, result.CorpusEligiblePlayerCount);
+    }
+
+    [Fact]
+    public void Compute_IgnoresPlayersBelowBenchmarkMinGames()
+    {
+        var result = _sut.Compute(
+            2.0,
+            "Fischer",
+            null,
+            new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Fischer", GameCount = 50, MetricValue = 2.0 },
+                new() { PlayerSurname = "Short", GameCount = 5, MetricValue = 0.5 }
+            },
+            benchmarkMinGames: 30);
+
+        Assert.Null(result.CorpusAverage);
+        Assert.Equal(0, result.CorpusEligiblePlayerCount);
+    }
+
+    [Theory]
+    [InlineData(1.0, new[] { 1.0, 2.0, 3.0 }, 0)]
+    [InlineData(3.0, new[] { 1.0, 2.0, 3.0 }, 66.666666666666686)]
+    [InlineData(2.0, new[] { 1.0, 2.0, 3.0 }, 33.333333333333336)]
+    [InlineData(4.0, new[] { 1.0, 2.0, 3.0 }, 100)]
+    public void ComputePercentile_RanksSubjectAgainstCorpus(double subject, double[] corpus, double expected)
+    {
+        var percentile = CorpusBenchmarkCalculator.ComputePercentile(subject, corpus);
+        Assert.Equal(expected, percentile, precision: 10);
+    }
+}

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -7,6 +7,8 @@ namespace ServicesTests.Analytics;
 
 public class MetricRegistryAndExecutorsTests
 {
+    private static readonly CorpusBenchmarkCalculator CorpusBenchmarkCalculator = new();
+
     [Fact]
     public void MetricRegistry_ContainsRegisteredMetricKeys()
     {
@@ -52,7 +54,7 @@ public class MetricRegistryAndExecutorsTests
             new PlayerResultSummaryExecutor(repo.Object),
             new AverageMaterialByPlayerAtMoveExecutor(repo.Object),
             new AverageCastlingPlyExecutor(repo.Object),
-            new AverageMaterialVolatilityExecutor(repo.Object),
+            new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator),
             new BishopPairFrequencyExecutor(repo.Object),
             new MinorPieceCompositionExecutor(repo.Object)
         });
@@ -655,7 +657,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new AverageMaterialVolatilityExecutor(repo.Object);
+        var sut = new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Tal",
@@ -673,7 +675,7 @@ public class MetricRegistryAndExecutorsTests
     public async Task AverageMaterialVolatilityExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new AverageMaterialVolatilityExecutor(repo.Object);
+        var sut = new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
     }
@@ -692,13 +694,55 @@ public class MetricRegistryAndExecutorsTests
             MinPlyIndex = 15,
             MaxPlyIndex = 40
         };
-        var sut = new AverageMaterialVolatilityExecutor(repo.Object);
+        var sut = new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 
         repo.Verify(r => r.GetAverageMaterialVolatilityAsync(
             It.Is<AnalyticsQuery>(q => q.MinPlyIndex == 15 && q.MaxPlyIndex == 40),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AverageMaterialVolatilityExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageMaterialVolatilityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AverageMaterialVolatilityRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Fischer",
+                    PlayerForenames = "Robert James",
+                    GameCount = 827,
+                    AverageMaterialVolatility = 1.34
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerAverageMaterialVolatilityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 827, MetricValue = 1.34 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 400, MetricValue = 1.0 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 350, MetricValue = 1.8 }
+            });
+
+        var sut = new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Fischer",
+            PlayerForenames = "Robert James",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            ["Player", "GameCount", "AverageMaterialVolatility", "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"],
+            result.ColumnNames);
+        Assert.Equal(1.34, result.Rows[0][2]);
+        Assert.Equal(1.4, result.Rows[0][3]);
+        Assert.Equal(-0.06, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(50.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds optional **corpus-relative benchmarks** for playing-style metrics (DESIGN §12 / PLAN §12.7). Raw scalars like `AverageMaterialVolatility = 1.34` are hard to interpret alone; this PR compares the subject player to other eligible players in the same database using the same filters.

`AverageMaterialVolatility` is the first metric wired end-to-end as a proof of concept. The metrics UI gains a checkbox and optional minimum-games threshold so benchmarks can be run without Swagger.

## Changes

- **Query extensions** — `AnalyticsQuery` adds `includeCorpusBenchmark` (default `false`) and `benchmarkMinGames` (default `30`).
- **Shared benchmark logic** — `ICorpusBenchmarkCalculator` / `CorpusBenchmarkCalculator` with leave-one-out corpus mean and percentile (`100 × count(corpus < subject) / n`).
- **AverageMaterialVolatility** — when benchmark is enabled, result rows append `CorpusAverage`, `DeltaFromCorpus`, `CorpusPercentile`, and `CorpusEligiblePlayerCount`; per-player SQL + repository method added.
- **UI** — corpus benchmark section in `index.html` (checkbox + `benchmarkMinGames`), shown for metrics in `CORPUS_BENCHMARK_METRICS` (currently `AverageMaterialVolatility` only).
- **Tests** — `CorpusBenchmarkCalculatorTests` plus executor coverage for benchmark columns when the flag is set.
- **Docs** — PLAN §12.7 steps 1–2 marked complete; `EXAMPLE_ANALYSES.md`, `MetricCatalog`, and related design notes updated.

## How to test

1. Load a PGN corpus with multiple players (e.g. Fischer + others).
2. Run **AverageMaterialVolatility** for a named player with year/ECO/colour filters as desired.
3. Enable **Include corpus benchmark** in the UI (or POST via API with `includeCorpusBenchmark: true`).
4. Confirm extra columns appear and values change sensibly when comparing two players on the same filters.
5. Run the test suite: `dotnet test`

**API example:**

```json
{
  "metricKey": "AverageMaterialVolatility",
  "query": {
    "playerSurname": "Fischer",
    "playerForenames": "Robert James",
    "includeCorpusBenchmark": true,
    "benchmarkMinGames": 30
  }
}