### PR TITLE
feat: add corpus benchmarks for BishopPairFrequency.

### DIFF
--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -125,7 +125,9 @@ internal static class MetricCatalog
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional: minPlyIndex, maxPlyIndex (defaults to 15 and 30 when both omitted)."
+                "Optional: minPlyIndex, maxPlyIndex (defaults to 15 and 30 when both omitted).",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "MinorPieceComposition" =>
             [

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -419,7 +419,8 @@
       var metricsCatalog = [];
 
       var CORPUS_BENCHMARK_METRICS = {
-        AverageMaterialVolatility: true
+        AverageMaterialVolatility: true,
+        BishopPairFrequency: true
       };
 
       function selectedMetricKey() {

--- a/src/Interfaces/Analytics/BishopPairFrequencyRow.cs
+++ b/src/Interfaces/Analytics/BishopPairFrequencyRow.cs
@@ -13,4 +13,12 @@ public sealed class BishopPairFrequencyRow
     public int? MinPlyIndex { get; init; }
 
     public int? MaxPlyIndex { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -155,6 +155,15 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player bishop-pair frequency aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerBishopPairFrequencyAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Mean per-game average bishops-minus-knights for the filtered player in a ply window.
         /// </summary>
         Task<IReadOnlyList<MinorPieceCompositionRow>> GetMinorPieceCompositionAsync(
@@ -914,6 +923,32 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = minPlyIndex,
+                        MaxPlyIndex = maxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerBishopPairFrequencyAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerBishopPairFrequency,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco),
                         MinPlyIndex = minPlyIndex,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -636,6 +636,79 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Per-player mean bishop-pair frequency for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerBishopPairFrequency =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       g.WhitePlayerId,
+                       g.BlackPlayerId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            PerPly AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       CASE
+                           WHEN a.PlayerSide = 'W' AND s.WhiteBishopCount = 2 THEN 1.0
+                           WHEN a.PlayerSide = 'B' AND s.BlackBishopCount = 2 THEN 1.0
+                           ELSE 0.0
+                       END AS HasBishopPair
+                FROM Appearances a
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = a.GameId
+                WHERE (@MinPlyIndex IS NULL OR s.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR s.PlyIndex <= @MaxPlyIndex)
+            ),
+            PerGame AS
+            (
+                SELECT PlayerSurname,
+                       PlayerForenames,
+                       GameId,
+                       AVG(HasBishopPair) AS BishopPairFrequency
+                FROM PerPly
+                GROUP BY PlayerSurname, PlayerForenames, GameId
+                HAVING COUNT(*) > 0
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(BishopPairFrequency) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Mean per-game average of bishops minus knights on the filtered player's side in a ply window.
         /// </summary>
         public static string GetMinorPieceComposition =>

--- a/src/Services/Analytics/BishopPairFrequencyExecutor.cs
+++ b/src/Services/Analytics/BishopPairFrequencyExecutor.cs
@@ -6,9 +6,13 @@ namespace Services.Analytics;
 /// <summary>
 /// Mean share of plies in a window where the player retains both bishops (PLAN §12.6 Phase 2).
 /// </summary>
-public sealed class BishopPairFrequencyExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class BishopPairFrequencyExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "BishopPairFrequency";
 
@@ -16,23 +20,88 @@ public sealed class BishopPairFrequencyExecutor(IChessRepository repository) : I
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
         var (minPly, maxPly) = PlayerStylePlyWindow.Resolve(query);
-        var rows = await _repository.GetBishopPairFrequencyAsync(query, minPly, maxPly, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetBishopPairFrequencyAsync(query, minPly, maxPly, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(BishopPairFrequencyRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerBishopPairFrequencyAsync(query, minPly, maxPly, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "AverageBishopPairFrequency", "MinPlyIndex", "MaxPlyIndex",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "AverageBishopPairFrequency", "MinPlyIndex", "MaxPlyIndex"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private BishopPairFrequencyRow EnrichWithBenchmark(
+        BishopPairFrequencyRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageBishopPairFrequency,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new BishopPairFrequencyRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            AverageBishopPairFrequency = row.AverageBishopPairFrequency,
+            MinPlyIndex = row.MinPlyIndex,
+            MaxPlyIndex = row.MaxPlyIndex,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(BishopPairFrequencyRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GameCount,
                 r.AverageBishopPairFrequency,
                 r.MinPlyIndex,
                 r.MaxPlyIndex
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GameCount", "AverageBishopPairFrequency", "MinPlyIndex", "MaxPlyIndex"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.AverageBishopPairFrequency,
+            r.MinPlyIndex,
+            r.MaxPlyIndex,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(BishopPairFrequencyRow row)

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -95,6 +95,12 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         int? maxPlyIndex,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<BishopPairFrequencyRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerBishopPairFrequencyAsync(
+        AnalyticsQuery query,
+        int? minPlyIndex,
+        int? maxPlyIndex,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<MinorPieceCompositionRow>> GetMinorPieceCompositionAsync(
         AnalyticsQuery query,
         int? minPlyIndex,

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -42,6 +42,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetBishopPairFrequencyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<BishopPairFrequencyRow>());
+        repo.Setup(r => r.GetPerPlayerBishopPairFrequencyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetMinorPieceCompositionAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<MinorPieceCompositionRow>());
         repo.Setup(r => r.GetCaptureRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
@@ -61,7 +63,7 @@ public class MetricRegistryAndExecutorsTests
             new AverageMaterialByPlayerAtMoveExecutor(repo.Object),
             new AverageCastlingPlyExecutor(repo.Object),
             new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new BishopPairFrequencyExecutor(repo.Object),
+            new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator),
             new MinorPieceCompositionExecutor(repo.Object),
             new CaptureRateExecutor(repo.Object),
             new QueenTradeRateExecutor(repo.Object)
@@ -779,7 +781,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new BishopPairFrequencyExecutor(repo.Object);
+        var sut = new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Karpov",
@@ -793,10 +795,65 @@ public class MetricRegistryAndExecutorsTests
     }
 
     [Fact]
+    public async Task BishopPairFrequencyExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetBishopPairFrequencyAsync(
+                It.IsAny<AnalyticsQuery>(),
+                15,
+                30,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BishopPairFrequencyRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GameCount = 120,
+                    AverageBishopPairFrequency = 0.55,
+                    MinPlyIndex = 15,
+                    MaxPlyIndex = 30
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerBishopPairFrequencyAsync(
+                It.IsAny<AnalyticsQuery>(),
+                15,
+                30,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Karpov", PlayerForenames = "Anatoly", GameCount = 120, MetricValue = 0.55 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 80, MetricValue = 0.35 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 70, MetricValue = 0.45 }
+            });
+
+        var sut = new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "AverageBishopPairFrequency", "MinPlyIndex", "MaxPlyIndex",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.55, result.Rows[0][2]);
+        Assert.Equal(0.4, result.Rows[0][5]);
+        Assert.Equal(0.15, (double)result.Rows[0][6]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][7]);
+        Assert.Equal(2, result.Rows[0][8]);
+    }
+
+    [Fact]
     public async Task BishopPairFrequencyExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new BishopPairFrequencyExecutor(repo.Object);
+        var sut = new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
     }


### PR DESCRIPTION
## Summary

Extends corpus-relative benchmarks (PLAN §12.7 step 3) to `BishopPairFrequency`. When `includeCorpusBenchmark` is enabled, the metric compares the subject player to other eligible players in the same database slice using the same year, ECO, colour, and ply-window filters.

## Changes

- **SQL** — `GetPerPlayerBishopPairFrequency` for per-player bishop-pair rates across the filtered corpus.
- **Repository** — `GetPerPlayerBishopPairFrequencyAsync`.
- **Executor** — `BishopPairFrequencyExecutor` enriches results via `ICorpusBenchmarkCalculator` when the benchmark flag is set.
- **DTO** — optional benchmark fields on `BishopPairFrequencyRow`.
- **UI** — `BishopPairFrequency` added to `CORPUS_BENCHMARK_METRICS` so the corpus benchmark checkbox appears for this metric.
- **Tests** — benchmark column coverage and registry/executor updates.

## How to test

1. `dotnet test`
2. Load a PGN corpus with multiple players.
3. Run **BishopPairFrequency** for a named player with optional year/ECO/colour filters.
4. Enable **Include corpus benchmark** in the UI (or set `includeCorpusBenchmark: true` via API).
5. Confirm columns: `CorpusAverage`, `DeltaFromCorpus`, `CorpusPercentile`, `CorpusEligiblePlayerCount`.

**API example:**

```json
{
  "metricKey": "BishopPairFrequency",
  "query": {
    "playerSurname": "Karpov",
    "playerForenames": "Anatoly",
    "includeCorpusBenchmark": true,
    "benchmarkMinGames": 30
  }
}