### PR TITLE
feat: add corpus benchmarks for MinorPieceComposition

### DIFF
--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -135,7 +135,9 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional: minPlyIndex, maxPlyIndex (defaults to 15 and 30 when both omitted).",
-                "AverageMinorPieceDelta > 0 indicates a bishop-oriented minor-piece mix."
+                "AverageMinorPieceDelta > 0 indicates a bishop-oriented minor-piece mix.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "CaptureRate" =>
             [

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -420,7 +420,8 @@
 
       var CORPUS_BENCHMARK_METRICS = {
         AverageMaterialVolatility: true,
-        BishopPairFrequency: true
+        BishopPairFrequency: true,
+        MinorPieceComposition: true
       };
 
       function selectedMetricKey() {

--- a/src/Interfaces/Analytics/MinorPieceCompositionRow.cs
+++ b/src/Interfaces/Analytics/MinorPieceCompositionRow.cs
@@ -13,4 +13,12 @@ public sealed class MinorPieceCompositionRow
     public int? MinPlyIndex { get; init; }
 
     public int? MaxPlyIndex { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -173,6 +173,15 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player minor-piece composition aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerMinorPieceCompositionAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Mean per-game capture rate for the filtered player's moves.
         /// </summary>
         Task<IReadOnlyList<CaptureRateRow>> GetCaptureRateAsync(
@@ -977,6 +986,32 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = minPlyIndex,
+                        MaxPlyIndex = maxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerMinorPieceCompositionAsync(
+            AnalyticsQuery query,
+            int? minPlyIndex,
+            int? maxPlyIndex,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerMinorPieceComposition,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco),
                         MinPlyIndex = minPlyIndex,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -766,6 +766,78 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Per-player mean minor-piece composition for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerMinorPieceComposition =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       g.WhitePlayerId,
+                       g.BlackPlayerId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            PerPly AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       CASE a.PlayerSide
+                           WHEN 'W' THEN CAST(s.WhiteBishopCount - s.WhiteKnightCount AS FLOAT)
+                           WHEN 'B' THEN CAST(s.BlackBishopCount - s.BlackKnightCount AS FLOAT)
+                       END AS MinorPieceDelta
+                FROM Appearances a
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = a.GameId
+                WHERE (@MinPlyIndex IS NULL OR s.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR s.PlyIndex <= @MaxPlyIndex)
+            ),
+            PerGame AS
+            (
+                SELECT PlayerSurname,
+                       PlayerForenames,
+                       GameId,
+                       AVG(MinorPieceDelta) AS AvgMinorPieceDelta
+                FROM PerPly
+                GROUP BY PlayerSurname, PlayerForenames, GameId
+                HAVING COUNT(*) > 0
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(AvgMinorPieceDelta) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Mean per-game capture rate for the filtered player's moves (capture ⇔ CapturedPiece IS NOT NULL).
         /// </summary>
         public static string GetCaptureRate =>

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -107,6 +107,12 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         int? maxPlyIndex,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<MinorPieceCompositionRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerMinorPieceCompositionAsync(
+        AnalyticsQuery query,
+        int? minPlyIndex,
+        int? maxPlyIndex,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<CaptureRateRow>> GetCaptureRateAsync(
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<CaptureRateRow>>();

--- a/src/Services/Analytics/MinorPieceCompositionExecutor.cs
+++ b/src/Services/Analytics/MinorPieceCompositionExecutor.cs
@@ -6,9 +6,13 @@ namespace Services.Analytics;
 /// <summary>
 /// Mean bishops-minus-knights count for a player across a ply window (PLAN §12.6 Phase 2).
 /// </summary>
-public sealed class MinorPieceCompositionExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class MinorPieceCompositionExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "MinorPieceComposition";
 
@@ -16,23 +20,88 @@ public sealed class MinorPieceCompositionExecutor(IChessRepository repository) :
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
         var (minPly, maxPly) = PlayerStylePlyWindow.Resolve(query);
-        var rows = await _repository.GetMinorPieceCompositionAsync(query, minPly, maxPly, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetMinorPieceCompositionAsync(query, minPly, maxPly, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(MinorPieceCompositionRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerMinorPieceCompositionAsync(query, minPly, maxPly, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "AverageMinorPieceDelta", "MinPlyIndex", "MaxPlyIndex",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "AverageMinorPieceDelta", "MinPlyIndex", "MaxPlyIndex"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private MinorPieceCompositionRow EnrichWithBenchmark(
+        MinorPieceCompositionRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageMinorPieceDelta,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new MinorPieceCompositionRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            AverageMinorPieceDelta = row.AverageMinorPieceDelta,
+            MinPlyIndex = row.MinPlyIndex,
+            MaxPlyIndex = row.MaxPlyIndex,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(MinorPieceCompositionRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GameCount,
                 r.AverageMinorPieceDelta,
                 r.MinPlyIndex,
                 r.MaxPlyIndex
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GameCount", "AverageMinorPieceDelta", "MinPlyIndex", "MaxPlyIndex"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.AverageMinorPieceDelta,
+            r.MinPlyIndex,
+            r.MaxPlyIndex,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(MinorPieceCompositionRow row)

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -46,6 +46,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetMinorPieceCompositionAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<MinorPieceCompositionRow>());
+        repo.Setup(r => r.GetPerPlayerMinorPieceCompositionAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetCaptureRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CaptureRateRow>());
         repo.Setup(r => r.GetQueenTradeRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -64,7 +66,7 @@ public class MetricRegistryAndExecutorsTests
             new AverageCastlingPlyExecutor(repo.Object),
             new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator),
             new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new MinorPieceCompositionExecutor(repo.Object),
+            new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator),
             new CaptureRateExecutor(repo.Object),
             new QueenTradeRateExecutor(repo.Object)
         });
@@ -880,7 +882,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new MinorPieceCompositionExecutor(repo.Object);
+        var sut = new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Tal",
@@ -899,10 +901,65 @@ public class MetricRegistryAndExecutorsTests
     }
 
     [Fact]
+    public async Task MinorPieceCompositionExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetMinorPieceCompositionAsync(
+                It.IsAny<AnalyticsQuery>(),
+                15,
+                30,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MinorPieceCompositionRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Tal",
+                    PlayerForenames = "Mikhail",
+                    GameCount = 90,
+                    AverageMinorPieceDelta = 0.6,
+                    MinPlyIndex = 15,
+                    MaxPlyIndex = 30
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerMinorPieceCompositionAsync(
+                It.IsAny<AnalyticsQuery>(),
+                15,
+                30,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 90, MetricValue = 0.6 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 85, MetricValue = 0.2 },
+                new() { PlayerSurname = "Karpov", PlayerForenames = "Anatoly", GameCount = 75, MetricValue = 0.4 }
+            });
+
+        var sut = new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "AverageMinorPieceDelta", "MinPlyIndex", "MaxPlyIndex",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.6, result.Rows[0][2]);
+        Assert.Equal(0.3, (double)result.Rows[0][5]!, precision: 10);
+        Assert.Equal(0.3, (double)result.Rows[0][6]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][7]);
+        Assert.Equal(2, result.Rows[0][8]);
+    }
+
+    [Fact]
     public async Task MinorPieceCompositionExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new MinorPieceCompositionExecutor(repo.Object);
+        var sut = new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
     }


### PR DESCRIPTION
## Summary

Extends corpus-relative benchmarks (PLAN §12.7 step 4) to `MinorPieceComposition`. When `includeCorpusBenchmark` is enabled, the metric compares the subject player's bishops-minus-knights mix to other eligible players in the same database slice using the same year, ECO, colour, and ply-window filters.

## Changes

- **SQL** — `GetPerPlayerMinorPieceComposition` for per-player minor-piece composition across the filtered corpus.
- **Repository** — `GetPerPlayerMinorPieceCompositionAsync`.
- **Executor** — `MinorPieceCompositionExecutor` enriches results via `ICorpusBenchmarkCalculator` when the benchmark flag is set.
- **DTO** — optional benchmark fields on `MinorPieceCompositionRow`.
- **UI** — `MinorPieceComposition` added to `CORPUS_BENCHMARK_METRICS`.
- **Tests** — benchmark column coverage and executor wiring updates.

## How to test

1. `dotnet test`
2. Load a PGN corpus with multiple players.
3. Run **MinorPieceComposition** for a named player with optional year/ECO/colour filters.
4. Enable **Include corpus benchmark** in the UI (or set `includeCorpusBenchmark: true` via API).
5. Confirm columns: `CorpusAverage`, `DeltaFromCorpus`, `CorpusPercentile`, `CorpusEligiblePlayerCount`.

## Notes

- Follow-up: PLAN §12.7 step 5 (`AverageCastlingPly` + benchmark).
- Percentiles are corpus-local (this database + filters), not universal chess history.
