### PR TITLE
feat: add corpus benchmarks for AverageCastlingPly

### DIFF
--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -109,7 +109,9 @@ internal static class MetricCatalog
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Games where the player never castled are excluded from the average; see GamesWithCastling."
+                "Games where the player never castled are excluded from the average; see GamesWithCastling.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "AverageMaterialVolatility" =>
             [

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -420,6 +420,7 @@
 
       var CORPUS_BENCHMARK_METRICS = {
         AverageMaterialVolatility: true,
+        AverageCastlingPly: true,
         BishopPairFrequency: true,
         MinorPieceComposition: true
       };

--- a/src/Interfaces/Analytics/AverageCastlingPlyRow.cs
+++ b/src/Interfaces/Analytics/AverageCastlingPlyRow.cs
@@ -9,4 +9,12 @@ public sealed class AverageCastlingPlyRow
     public int GamesWithCastling { get; init; }
 
     public double? AverageCastlingPly { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -132,6 +132,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player mean first-castling ply aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageCastlingPlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Mean per-game standard deviation of signed material balance for a filtered player.
         /// </summary>
         Task<IReadOnlyList<AverageMaterialVolatilityRow>> GetAverageMaterialVolatilityAsync(
@@ -856,6 +863,28 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageCastlingPlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerAverageCastlingPly,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -451,6 +451,64 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Per-player mean first-castling ply for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerAverageCastlingPly =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            FirstCastle AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       MIN(m.PlyIndex) AS CastlingPly
+                FROM Appearances a
+                INNER JOIN dbo.GameMove m ON m.GameId = a.GameId
+                WHERE (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                  AND m.MovingSide = a.PlayerSide
+                GROUP BY a.PlayerSurname, a.PlayerForenames, a.GameId
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(CAST(CastlingPly AS FLOAT)) AS MetricValue
+            FROM FirstCastle
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Mean per-game sample standard deviation of signed material balance from the player's perspective.
         /// </summary>
         public static string GetAverageMaterialVolatility =>

--- a/src/Services/Analytics/AverageCastlingPlyExecutor.cs
+++ b/src/Services/Analytics/AverageCastlingPlyExecutor.cs
@@ -6,30 +6,95 @@ namespace Services.Analytics;
 /// <summary>
 /// Mean half-move of the filtered player's first castle (PLAN §12.6 Phase 1).
 /// </summary>
-public sealed class AverageCastlingPlyExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class AverageCastlingPlyExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "AverageCastlingPly";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetAverageCastlingPlyAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetAverageCastlingPlyAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(AverageCastlingPlyRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerAverageCastlingPlyAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GamesWithCastling", "AverageCastlingPly",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GamesWithCastling", "AverageCastlingPly"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private AverageCastlingPlyRow EnrichWithBenchmark(
+        AverageCastlingPlyRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageCastlingPly,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new AverageCastlingPlyRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GamesWithCastling = row.GamesWithCastling,
+            AverageCastlingPly = row.AverageCastlingPly,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(AverageCastlingPlyRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GamesWithCastling,
                 r.AverageCastlingPly
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GamesWithCastling", "AverageCastlingPly"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GamesWithCastling,
+            r.AverageCastlingPly,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(AverageCastlingPlyRow row)

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -81,6 +81,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<AverageCastlingPlyRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageCastlingPlyAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<AverageMaterialVolatilityRow>> GetAverageMaterialVolatilityAsync(
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<AverageMaterialVolatilityRow>>();

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -36,6 +36,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<PlayerMaterialAverageRow>());
         repo.Setup(r => r.GetAverageCastlingPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AverageCastlingPlyRow>());
+        repo.Setup(r => r.GetPerPlayerAverageCastlingPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetAverageMaterialVolatilityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AverageMaterialVolatilityRow>());
         repo.Setup(r => r.GetPerPlayerAverageMaterialVolatilityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
@@ -63,7 +65,7 @@ public class MetricRegistryAndExecutorsTests
             new GameCountByPlayerExecutor(repo.Object),
             new PlayerResultSummaryExecutor(repo.Object),
             new AverageMaterialByPlayerAtMoveExecutor(repo.Object),
-            new AverageCastlingPlyExecutor(repo.Object),
+            new AverageCastlingPlyExecutor(repo.Object, CorpusBenchmarkCalculator),
             new AverageMaterialVolatilityExecutor(repo.Object, CorpusBenchmarkCalculator),
             new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator),
             new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator),
@@ -601,7 +603,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new AverageCastlingPlyExecutor(repo.Object);
+        var sut = new AverageCastlingPlyExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Petrosian",
@@ -616,10 +618,55 @@ public class MetricRegistryAndExecutorsTests
     }
 
     [Fact]
+    public async Task AverageCastlingPlyExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageCastlingPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AverageCastlingPlyRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Petrosian",
+                    PlayerForenames = "Tigran",
+                    GamesWithCastling = 100,
+                    AverageCastlingPly = 12.0
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerAverageCastlingPlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 100, MetricValue = 12.0 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 80, MetricValue = 8.0 },
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 90, MetricValue = 10.0 }
+            });
+
+        var sut = new AverageCastlingPlyExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Petrosian",
+            PlayerForenames = "Tigran",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GamesWithCastling", "AverageCastlingPly",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(12.0, result.Rows[0][2]);
+        Assert.Equal(9.0, result.Rows[0][3]);
+        Assert.Equal(3.0, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
+    }
+
+    [Fact]
     public async Task AverageCastlingPlyExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new AverageCastlingPlyExecutor(repo.Object);
+        var sut = new AverageCastlingPlyExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
     }
@@ -640,7 +687,7 @@ public class MetricRegistryAndExecutorsTests
             MaxGameYear = 1970,
             Eco = "B90"
         };
-        var sut = new AverageCastlingPlyExecutor(repo.Object);
+        var sut = new AverageCastlingPlyExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 


### PR DESCRIPTION
## Summary
- Add corpus-relative benchmark columns (`CorpusAverage`, `DeltaFromCorpus`, `CorpusPercentile`, `CorpusEligiblePlayerCount`) to `AverageCastlingPly` when `includeCorpusBenchmark` is set.
- Add per-player SQL/repository support and wire the executor through `ICorpusBenchmarkCalculator`, following the same pattern as other style metrics (PLAN §12.7).
- Enable the corpus benchmark UI checkbox for this metric and add tests.

## Test plan
- [x] `dotnet test` passes
- [x] Run `AverageCastlingPly` with `includeCorpusBenchmark=true` against a populated DB and verify benchmark columns appear
- [x] Confirm corpus checkbox is shown in the metrics UI when `AverageCastlingPly` is selected
