### PR TITLE
feat: add corpus benchmarks for QueenTradeRate

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (PLAN §12.7 v1 complete; `CaptureRate` corpus benchmark in progress on feature branch.)
+**Last updated:** 2026-06-11 (PR #57 QueenTradeRate corpus benchmarks — conflicts with merged #56 resolved.)
 
 ---
 
@@ -13,7 +13,7 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 | File | Role |
 |------|------|
 | [DESIGN.md](./DESIGN.md) | Requirements and locked decisions; **§12** corpus benchmarks (F-11). |
-| [PLAN.md](./PLAN.md) | Implementation plan; **§12.6** (style metrics), **§12.7** (corpus benchmarks — v1 done). |
+| [PLAN.md](./PLAN.md) | Implementation plan; **§12.6** (style metrics), **§12.7** (corpus benchmarks). |
 | [STYLE_METRICS.md](./STYLE_METRICS.md) | Style research, literature, metric catalogue, profile combinations, caveats. |
 | **AGENT_CONTEXT.md** (this file) | Current progress and **recommended next small step**. |
 
@@ -24,62 +24,52 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 ## 2. Product state (high level)
 
 - **Done:** PGN parse → player resolution → bitboard positions per ply → persist **`Game`**, **`BoardPosition`**, **`Player`**, parse errors. GitHub Actions runs **`dotnet test`** on PRs.
-- **Housekeeping added:** schema-history scaffolding (`src/Migrations/History/` + `tools/export-db-history.ps1`) to snapshot current SQL object DDL after migrations.
-- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics JSON on `Analyser`: `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute`). **Done (local UI/discovery):** unified **`wwwroot`** web experience for ETL + metrics + game browse, player material comparison UI, metrics discovery descriptions plus parameter hints, independent metric player filters (`playerSurname`/`playerForenames` + `playerColour`), and corpus benchmark checkbox in the metrics form. **Done (metrics surface):** `GameCountByEco`, `AverageMaterialByPlayerAtMove`, `GameCountByYear`, `GameCountByResult`, `GameCountByPlayer`, `PlayerResultSummary`, `AverageCastlingPly`, `AverageMaterialVolatility`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate`, `QueenTradeRate`. **Corpus benchmarks (§12.7 v1):** `AverageMaterialVolatility`, `AverageCastlingPly`, `BishopPairFrequency`, `MinorPieceComposition`; **`CaptureRate`** on feature branch. **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (owner decision; see PLAN §12.1 / §12.4).
+- **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics HTTP API + local **`wwwroot`** UI).
+- **Done (style metrics Phases 1–3):** `AverageCastlingPly`, `AverageMaterialVolatility`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate`, `QueenTradeRate`.
+- **Done (corpus benchmarks on main):** `AverageMaterialVolatility`, `AverageCastlingPly`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate` (PR #56).
+- **In flight:** `QueenTradeRate` corpus benchmarks — [PR #57](https://github.com/pauloggs/ChessAnalyser/pull/57) (rebased onto main after #56 merge; conflicts resolved).
+- **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
 
-## 3. Recommended next step (small slice)
+## 3. Workflow — when the user says **“next step”**
 
-**Do next:** Merge `feat/corpus-benchmark-capture-rate` (corpus benchmarks for `CaptureRate`), then add the same for **`QueenTradeRate`**.
+**Always follow this sequence (one PR-sized slice per step):**
 
-**Then:** §12.6 Phase 4 spatial metrics (`CentreMoveRate`, `ForwardMoveRate`).
+1. **`git fetch origin`** and **`git checkout main && git pull origin main`** — start from latest merged `main` only.
+2. **`git checkout -b feat/<short-description>`** — new branch for this slice only.
+3. **Implement** the next unchecked item in [PLAN.md](./PLAN.md) (or the slice named in §3.1 below).
+4. **`dotnet test`** — must pass before push.
+5. **Commit, push, `gh pr create`** — one PR per step; do **not** stack unrelated metrics on the same branch.
+6. **Update this file** (§2 / §3.1) in the same PR when the slice changes backlog state.
 
-**Do not prioritize yet:** Dedicated HTTP **auth / rate limits** for `AnalyticsMetricsController` — **out of scope** until there is a **deployment or network exposure** plan (then treat as blocking; update PLAN §12.1 / §13). Optional hygiene: bind the dev host to **localhost** only.
+**Do not:** branch from an older feature branch, open a second PR while the first is unmerged, or implement the next metric before the previous PR is on `main` (avoids merge conflicts in shared files: executors, `SqlStatements.cs`, `index.html`, tests).
+
+### 3.1 Recommended next step (small slice)
+
+**Do next (after PR #57 merges):** [PLAN.md §12.6 Phase 4](./PLAN.md) — implement **`CentreMoveRate`** (first spatial metric; corpus benchmark optional follow-up per §12.7 pattern).
+
+**Then:** `ForwardMoveRate`, then Phase 5+ per PLAN.
+
+**Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 
 ---
 
 ## 4. Checklist mirror (PLAN §11)
 
-Sync this subsection when items complete (or rely on `PLAN.md` checkboxes only — but then tick **PLAN.md** in git).
-
-- [x] 1. `006_AddGameAnalyticsColumns.sql` + Migrations README (run DbUp locally to verify against your DB)
-- [x] 2. `007_CreateGameMoveTable.sql`
-- [x] 3. `008_CreateGamePositionSummaryTable.sql`
-- [x] 4–5. `Game` DTO + `InsertGame` + `PgnGameHeaderMapper` / `PersistenceService`
-- [x] 6. `IPieceValues` + `IGamePositionSummaryFactory` + `GamePositionSummary`
-- [x] 7. `GameMoveDeriver` + tests
-- [x] 8. Repository `SqlStatements` + replace/read for `GameMove` and `GamePositionSummary`
-- [x] 9. `IAnalyticsMaterializationService` + ETL wiring after board insert
-- [x] 10. `IMetricRegistry` + reference metric executors + tests
-- [x] 11. `IAnalyticsBackfillService` + Analyser `--backfill-analytics` CLI
-- [x] 12. Materialization perf smoke (`docs/ANALYTICS_MATERIALIZATION_PERF.md`, `--profile-materialization`)
-- [x] 13. `src/Migrations/README.md` analytics / tooling notes
-
-### 4.1 PLAN §12 (Stage 4 — mirror)
-
-- [x] 1–5. Metrics HTTP API + DESIGN F-9 / Q7 (see [PLAN.md §12](./PLAN.md))
-
-**As of last update:** PLAN §11 items **1–13** and §12 checklist in source control; ensure DbUp has applied through `010` if you use analytics tables locally.
-
-**CLI (Analyser, no web host):** `--backfill-analytics` (optional `--max-games N`); `--profile-materialization` (optional `--iterations N`, default 5000). Both exit after console output.
-
-**HTTP (Analyser web host):** `GET /api/analytics/metrics`, `POST /api/analytics/metrics/execute` — **no auth** while local-only; **defer** auth/rate limits until deployment (PLAN §12.4 / §13); see controller remarks.
+- [x] Items 1–13 — see [PLAN.md §11](./PLAN.md)
+- [x] PLAN §12 metrics HTTP API (Stage 4)
 
 ---
 
 ## 5. Technical snapshot
 
-- **`dbo.Game`:** plus **`Event`**, **`Site`**, **`DateTag`**, **`GameYear`**, **`Eco`** — populated on insert via **`PgnGameHeaderMapper`** from lowercase PGN tags (`event`, `site`, `date`, `eco`). **`GameYear`** is set only when the date looks like PGN `YYYY.MM…` with a four-digit year and no `?` in the year.
-- **`dbo.BoardPosition`:** `(GameId, PlyIndex)`; `PlyIndex = -1` initial; half-moves `0,1,…`.
-- **Rollups (in code):** **`ClassicalPieceValues`** + **`GamePositionSummaryFactory`** produce **`GamePositionSummary`** DTOs; **`ChessRepository.ReplaceGamePositionSummariesForGame`** persists them (ETL + backfill via **`IAnalyticsMaterializationService`**).
-- **Move facts:** **`GameMoveDeriver`** → **`GameMoveFact`**; **`ChessRepository.ReplaceGameMovesForGame`** persists rows (same path). CPU perf smoke: [ANALYTICS_MATERIALIZATION_PERF.md](./ANALYTICS_MATERIALIZATION_PERF.md) and **`--profile-materialization`** on Analyser.
-- **Metrics HTTP:** **`AnalyticsMetricsController`** wraps **`IMetricRegistry`** (discovery + execute); internal executors unchanged.
-- **Conventions:** See [PLAN.md §7](./PLAN.md) and [DESIGN.md §8](./DESIGN.md).
+- **`dbo.GameMove`** + **`dbo.GamePositionSummary`** — derived on ETL/backfill; required for style metrics.
+- **Corpus benchmarks:** opt-in `includeCorpusBenchmark` + `benchmarkMinGames` (default 30); shared `ICorpusBenchmarkCalculator`.
+- **Conventions:** [PLAN.md §7](./PLAN.md), [DESIGN.md §8](./DESIGN.md).
 
 ---
 
 ## 6. Maintenance
 
-- After each session: bump **Last updated**, refresh **§3** / **§4**, and tick items in **`docs/PLAN.md` §11** when done.
-- Renamed from `HANDOVER.md` → **`AGENT_CONTEXT.md`** (2026-05-10); update any bookmarks or external links.
+- After each session: bump **Last updated**, refresh **§2** / **§3.1**, tick **PLAN.md** when items complete.

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -153,7 +153,9 @@ internal static class MetricCatalog
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "Optional: queenTradeMaxPly (defaults to 40 when omitted)."
+                "Optional: queenTradeMaxPly (defaults to 40 when omitted).",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             _ => []
         };

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -422,7 +422,8 @@
         AverageMaterialVolatility: true,
         AverageCastlingPly: true,
         BishopPairFrequency: true,
-        MinorPieceComposition: true
+        MinorPieceComposition: true,
+        QueenTradeRate: true
       };
 
       function selectedMetricKey() {

--- a/src/Interfaces/Analytics/QueenTradeRateRow.cs
+++ b/src/Interfaces/Analytics/QueenTradeRateRow.cs
@@ -11,4 +11,12 @@ public sealed class QueenTradeRateRow
     public double? QueenTradeRate { get; init; }
 
     public int QueenTradeMaxPly { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -204,6 +204,14 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player early queen trade rate aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerQueenTradeRateAsync(
+            AnalyticsQuery query,
+            int queenTradeMaxPly,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1094,6 +1102,30 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        QueenTradeMaxPly = queenTradeMaxPly
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerQueenTradeRateAsync(
+            AnalyticsQuery query,
+            int queenTradeMaxPly,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerQueenTradeRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco),
                         QueenTradeMaxPly = queenTradeMaxPly

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1007,6 +1007,73 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Per-player early queen trade rate for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerQueenTradeRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            FirstQueenTrade AS
+            (
+                SELECT fg.GameId,
+                       MIN(s.PlyIndex) AS QueenTradePly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = fg.GameId
+                WHERE s.WhiteQueenCount <> 1 OR s.BlackQueenCount <> 1
+                GROUP BY fg.GameId
+            ),
+            PerGame AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       CASE
+                           WHEN ft.QueenTradePly IS NOT NULL AND ft.QueenTradePly <= @QueenTradeMaxPly THEN 1.0
+                           ELSE 0.0
+                       END AS EarlyQueenTrade
+                FROM Appearances a
+                LEFT JOIN FirstQueenTrade ft ON ft.GameId = a.GameId
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(EarlyQueenTrade) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -126,6 +126,11 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         int queenTradeMaxPly,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<QueenTradeRateRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerQueenTradeRateAsync(
+        AnalyticsQuery query,
+        int queenTradeMaxPly,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/src/Services/Analytics/QueenTradeRateExecutor.cs
+++ b/src/Services/Analytics/QueenTradeRateExecutor.cs
@@ -6,9 +6,13 @@ namespace Services.Analytics;
 /// <summary>
 /// Share of games with queens off the board on or before a ply threshold (PLAN §12.6 Phase 3).
 /// </summary>
-public sealed class QueenTradeRateExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class QueenTradeRateExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "QueenTradeRate";
 
@@ -16,22 +20,85 @@ public sealed class QueenTradeRateExecutor(IChessRepository repository) : IMetri
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
         var queenTradeMaxPly = QueenTradeMaxPlyDefaults.Resolve(query);
-        var rows = await _repository.GetQueenTradeRateAsync(query, queenTradeMaxPly, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetQueenTradeRateAsync(query, queenTradeMaxPly, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(QueenTradeRateRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerQueenTradeRateAsync(query, queenTradeMaxPly, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "QueenTradeRate", "QueenTradeMaxPly",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "QueenTradeRate", "QueenTradeMaxPly"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private QueenTradeRateRow EnrichWithBenchmark(
+        QueenTradeRateRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.QueenTradeRate,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new QueenTradeRateRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            QueenTradeRate = row.QueenTradeRate,
+            QueenTradeMaxPly = row.QueenTradeMaxPly,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(QueenTradeRateRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GameCount,
                 r.QueenTradeRate,
                 r.QueenTradeMaxPly
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GameCount", "QueenTradeRate", "QueenTradeMaxPly"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.QueenTradeRate,
+            r.QueenTradeMaxPly,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(QueenTradeRateRow row)

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -54,6 +54,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<CaptureRateRow>());
         repo.Setup(r => r.GetQueenTradeRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<QueenTradeRateRow>());
+        repo.Setup(r => r.GetPerPlayerQueenTradeRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -70,7 +72,7 @@ public class MetricRegistryAndExecutorsTests
             new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator),
             new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator),
             new CaptureRateExecutor(repo.Object),
-            new QueenTradeRateExecutor(repo.Object)
+            new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -1093,7 +1095,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new QueenTradeRateExecutor(repo.Object);
+        var sut = new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Petrosian",
@@ -1108,10 +1110,62 @@ public class MetricRegistryAndExecutorsTests
     }
 
     [Fact]
+    public async Task QueenTradeRateExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetQueenTradeRateAsync(
+                It.IsAny<AnalyticsQuery>(),
+                40,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<QueenTradeRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Petrosian",
+                    PlayerForenames = "Tigran",
+                    GameCount = 90,
+                    QueenTradeRate = 0.60,
+                    QueenTradeMaxPly = 40
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerQueenTradeRateAsync(
+                It.IsAny<AnalyticsQuery>(),
+                40,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 0.60 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 80, MetricValue = 0.30 },
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 70, MetricValue = 0.45 }
+            });
+
+        var sut = new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Petrosian",
+            PlayerForenames = "Tigran",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "QueenTradeRate", "QueenTradeMaxPly",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.60, result.Rows[0][2]);
+        Assert.Equal(0.375, result.Rows[0][4]);
+        Assert.Equal(0.225, (double)result.Rows[0][5]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][6]);
+        Assert.Equal(2, result.Rows[0][7]);
+    }
+
+    [Fact]
     public async Task QueenTradeRateExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new QueenTradeRateExecutor(repo.Object);
+        var sut = new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
     }
@@ -1135,7 +1189,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new QueenTradeRateExecutor(repo.Object);
+        var sut = new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator);
         await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Karpov",


### PR DESCRIPTION
## Summary
- Add corpus-relative benchmark columns to `QueenTradeRate` when `includeCorpusBenchmark` is set.
- Add per-player SQL/repository support and wire the executor through `ICorpusBenchmarkCalculator`.
- Enable the corpus benchmark UI checkbox for this metric.

## Test plan
- [x] `dotnet test` passes (including `QueenTradeRateExecutor_AppendsBenchmarkColumns_WhenRequested`)
- [ ] Run `QueenTradeRate` with `includeCorpusBenchmark=true` against a populated DB
- [ ] Confirm corpus checkbox appears when `QueenTradeRate` is selected in the metrics UI
