### PR TITLE
feat: add CentreMoveRate style metric

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (PR #57 QueenTradeRate corpus benchmarks — conflicts with merged #56 resolved.)
+**Last updated:** 2026-06-11 (`CentreMoveRate` metric — PR in flight.)
 
 ---
 
@@ -27,7 +27,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics HTTP API + local **`wwwroot`** UI).
 - **Done (style metrics Phases 1–3):** `AverageCastlingPly`, `AverageMaterialVolatility`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate`, `QueenTradeRate`.
 - **Done (corpus benchmarks on main):** `AverageMaterialVolatility`, `AverageCastlingPly`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate` (PR #56).
-- **In flight:** `QueenTradeRate` corpus benchmarks — [PR #57](https://github.com/pauloggs/ChessAnalyser/pull/57) (rebased onto main after #56 merge; conflicts resolved).
+- **Done (corpus benchmarks):** `QueenTradeRate` (PR #57).
+- **In flight:** `CentreMoveRate` spatial metric (Phase 4).
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -47,9 +48,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next (after PR #57 merges):** [PLAN.md §12.6 Phase 4](./PLAN.md) — implement **`CentreMoveRate`** (first spatial metric; corpus benchmark optional follow-up per §12.7 pattern).
+**Do next (after CentreMoveRate PR merges):** [PLAN.md §12.6 Phase 4](./PLAN.md) — implement **`ForwardMoveRate`**.
 
-**Then:** `ForwardMoveRate`, then Phase 5+ per PLAN.
+**Then:** Phase 5+ per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -497,7 +497,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
 
 #### Phase 4 — spatial aggression
 
-7. [ ] **`CentreMoveRate`**
+7. [x] **`CentreMoveRate`**
    - **Question:** How often does a player play to central squares?
    - **Data:** `GameMove` — `ToSquare` in centre set **{d4, d5, e4, e5}** (square indices 27, 28,
      35, 36 with a1 = 0).

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -40,6 +40,8 @@ internal static class MetricCatalog
                 "Mean per-game share of the filtered player's moves that are captures.",
             "QueenTradeRate" =>
                 "Share of games where queens are no longer both on the board on or before a ply threshold (default queenTradeMaxPly 40).",
+            "CentreMoveRate" =>
+                "Mean per-game share of the filtered player's moves landing on central squares d4, d5, e4, e5.",
             _ => null
         };
     }
@@ -158,6 +160,14 @@ internal static class MetricCatalog
                 "Optional: queenTradeMaxPly (defaults to 40 when omitted).",
                 "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
                 "Optional: benchmarkMinGames (default 30) for corpus eligibility."
+            ],
+            "CentreMoveRate" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: minPlyIndex, maxPlyIndex to restrict which move plies count.",
+                "Centre squares are d4, d5, e4, e5 (ToSquare 27, 28, 35, 36)."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -97,6 +97,7 @@ builder.Services.AddScoped<IMetricExecutor, BishopPairFrequencyExecutor>();
 builder.Services.AddScoped<IMetricExecutor, MinorPieceCompositionExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CaptureRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, QueenTradeRateExecutor>();
+builder.Services.AddScoped<IMetricExecutor, CentreMoveRateExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/CentreMoveRateRow.cs
+++ b/src/Interfaces/Analytics/CentreMoveRateRow.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.Analytics;
+
+public sealed class CentreMoveRateRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? AverageCentreMoveRate { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -219,6 +219,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Mean per-game share of moves landing on central squares d4, d5, e4, e5.
+        /// </summary>
+        Task<IReadOnlyList<CentreMoveRateRow>> GetCentreMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1160,6 +1167,32 @@ namespace Repositories
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco),
                         QueenTradeMaxPly = queenTradeMaxPly
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<CentreMoveRateRow>> GetCentreMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<CentreMoveRateRow>(
+                new CommandDefinition(
+                    SqlStatements.GetCentreMoveRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = query.MinPlyIndex,
+                        MaxPlyIndex = query.MaxPlyIndex
                     },
                     cancellationToken: cancellationToken))).ToList();
 

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1143,6 +1143,61 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Mean per-game share of moves to central squares d4, d5, e4, e5 (ToSquare 27, 28, 35, 36).
+        /// </summary>
+        public static string GetCentreMoveRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            PlayerMoves AS
+            (
+                SELECT fg.GameId,
+                       SUM(CASE WHEN m.ToSquare IN (27, 28, 35, 36) THEN 1 ELSE 0 END) AS CentreCount,
+                       COUNT(*) AS MoveCount
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND m.MovingSide = fg.PlayerSide
+                  AND (@MinPlyIndex IS NULL OR m.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR m.PlyIndex <= @MaxPlyIndex)
+                GROUP BY fg.GameId
+                HAVING COUNT(*) > 0
+            ),
+            PerGame AS
+            (
+                SELECT GameId,
+                       CAST(CentreCount AS FLOAT) / MoveCount AS CentreMoveRate
+                FROM PlayerMoves
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(CentreMoveRate) AS AverageCentreMoveRate
+            FROM PerGame;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/CentreMoveRateExecutor.cs
+++ b/src/Services/Analytics/CentreMoveRateExecutor.cs
@@ -1,0 +1,42 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean per-game share of moves landing on central squares d4, d5, e4, e5 (PLAN §12.6 Phase 4).
+/// </summary>
+public sealed class CentreMoveRateExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "CentreMoveRate";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetCentreMoveRateAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(CentreMoveRateRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GameCount,
+                r.AverageCentreMoveRate
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GameCount", "AverageCentreMoveRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(CentreMoveRateRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -135,6 +135,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         int queenTradeMaxPly,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
 
+    public Task<IReadOnlyList<CentreMoveRateRow>> GetCentreMoveRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<CentreMoveRateRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -58,6 +58,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<QueenTradeRateRow>());
         repo.Setup(r => r.GetPerPlayerQueenTradeRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
+        repo.Setup(r => r.GetCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CentreMoveRateRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -74,7 +76,8 @@ public class MetricRegistryAndExecutorsTests
             new BishopPairFrequencyExecutor(repo.Object, CorpusBenchmarkCalculator),
             new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator),
             new CaptureRateExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator)
+            new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new CentreMoveRateExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -91,7 +94,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("MinorPieceComposition", sut.MetricKeys);
         Assert.Contains("CaptureRate", sut.MetricKeys);
         Assert.Contains("QueenTradeRate", sut.MetricKeys);
-        Assert.Equal(14, sut.MetricKeys.Count);
+        Assert.Contains("CentreMoveRate", sut.MetricKeys);
+        Assert.Equal(15, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -1246,6 +1250,68 @@ public class MetricRegistryAndExecutorsTests
         repo.Verify(r => r.GetQueenTradeRateAsync(
             It.IsAny<AnalyticsQuery>(),
             30,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CentreMoveRateExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CentreMoveRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Kasparov",
+                    PlayerForenames = "Garry",
+                    GameCount = 10,
+                    AverageCentreMoveRate = 0.22
+                }
+            });
+
+        var sut = new CentreMoveRateExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry"
+        });
+
+        Assert.Equal(["Player", "GameCount", "AverageCentreMoveRate"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Kasparov, Garry", result.Rows[0][0]);
+        Assert.Equal(10, result.Rows[0][1]);
+        Assert.Equal(0.22, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task CentreMoveRateExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new CentreMoveRateExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task CentreMoveRateExecutor_PassesPlyWindowToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CentreMoveRateRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail",
+            MinPlyIndex = 5,
+            MaxPlyIndex = 40
+        };
+        var sut = new CentreMoveRateExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetCentreMoveRateAsync(
+            It.Is<AnalyticsQuery>(q => q.MinPlyIndex == 5 && q.MaxPlyIndex == 40),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Add `CentreMoveRate` — mean per-game share of a player's moves landing on central squares d4, d5, e4, e5 (PLAN §12.6 Phase 4).
- SQL aggregates from `GameMove.ToSquare` with optional `minPlyIndex` / `maxPlyIndex` window.
- Register executor, `MetricCatalog` hints, and unit tests.

## Test plan
- [x] `dotnet test` passes (including `CentreMoveRateExecutor_*` tests)
- [ ] Run `CentreMoveRate` for a known player against a populated DB
- [ ] Confirm metric appears in `GET /api/analytics/metrics` and runs from the UI
