### PR TITLE
feat: add ForwardMoveRate style metric

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`CentreMoveRate` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`ForwardMoveRate` metric — PR in flight.)
 
 ---
 
@@ -28,7 +28,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (style metrics Phases 1–3):** `AverageCastlingPly`, `AverageMaterialVolatility`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate`, `QueenTradeRate`.
 - **Done (corpus benchmarks on main):** `AverageMaterialVolatility`, `AverageCastlingPly`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate` (PR #56).
 - **Done (corpus benchmarks):** `QueenTradeRate` (PR #57).
-- **In flight:** `CentreMoveRate` spatial metric (Phase 4).
+- **Done (Phase 4):** `CentreMoveRate` (PR #58).
+- **In flight:** `ForwardMoveRate` spatial metric (Phase 4).
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -48,9 +49,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next (after CentreMoveRate PR merges):** [PLAN.md §12.6 Phase 4](./PLAN.md) — implement **`ForwardMoveRate`**.
+**Do next (after ForwardMoveRate PR merges):** [PLAN.md §12.6 Phase 5](./PLAN.md) — implement **`CastlingSidePreference`**.
 
-**Then:** Phase 5+ per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
+**Then:** `OppositeSideCastlingRate` and Phase 6+ per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -506,7 +506,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
    - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageCentreMoveRate`.
    - **Optional v2:** extend centre ring to c3–f6 (document if added).
 
-8. [ ] **`ForwardMoveRate`**
+8. [x] **`ForwardMoveRate`**
    - **Question:** How often does a player advance into the opponent's half?
    - **Data:** `GameMove` — `ToSquare` rank index (0–7) compared to moving side (White: rank ≥ 4;
      Black: rank ≤ 3).

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -42,6 +42,8 @@ internal static class MetricCatalog
                 "Share of games where queens are no longer both on the board on or before a ply threshold (default queenTradeMaxPly 40).",
             "CentreMoveRate" =>
                 "Mean per-game share of the filtered player's moves landing on central squares d4, d5, e4, e5.",
+            "ForwardMoveRate" =>
+                "Mean per-game share of the filtered player's moves landing in the opponent's half of the board.",
             _ => null
         };
     }
@@ -168,6 +170,14 @@ internal static class MetricCatalog
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional: minPlyIndex, maxPlyIndex to restrict which move plies count.",
                 "Centre squares are d4, d5, e4, e5 (ToSquare 27, 28, 35, 36)."
+            ],
+            "ForwardMoveRate" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: minPlyIndex, maxPlyIndex to restrict which move plies count.",
+                "Forward for White means ToSquare rank index >= 4; for Black, rank index <= 3."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -98,6 +98,7 @@ builder.Services.AddScoped<IMetricExecutor, MinorPieceCompositionExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CaptureRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, QueenTradeRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CentreMoveRateExecutor>();
+builder.Services.AddScoped<IMetricExecutor, ForwardMoveRateExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/ForwardMoveRateRow.cs
+++ b/src/Interfaces/Analytics/ForwardMoveRateRow.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.Analytics;
+
+public sealed class ForwardMoveRateRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? AverageForwardMoveRate { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -226,6 +226,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Mean per-game share of moves landing in the opponent's half.
+        /// </summary>
+        Task<IReadOnlyList<ForwardMoveRateRow>> GetForwardMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1183,6 +1190,32 @@ namespace Repositories
             var rows = (await connection.QueryAsync<CentreMoveRateRow>(
                 new CommandDefinition(
                     SqlStatements.GetCentreMoveRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = query.MinPlyIndex,
+                        MaxPlyIndex = query.MaxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<ForwardMoveRateRow>> GetForwardMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<ForwardMoveRateRow>(
+                new CommandDefinition(
+                    SqlStatements.GetForwardMoveRate,
                     new
                     {
                         MinGameYear = query.MinGameYear,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1198,6 +1198,65 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Mean per-game share of moves into the opponent's half (White: rank index ≥ 4; Black: rank index ≤ 3).
+        /// </summary>
+        public static string GetForwardMoveRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            PlayerMoves AS
+            (
+                SELECT fg.GameId,
+                       SUM(CASE
+                               WHEN m.MovingSide = 'W' AND (m.ToSquare / 8) >= 4 THEN 1
+                               WHEN m.MovingSide = 'B' AND (m.ToSquare / 8) <= 3 THEN 1
+                               ELSE 0
+                           END) AS ForwardCount,
+                       COUNT(*) AS MoveCount
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND m.MovingSide = fg.PlayerSide
+                  AND (@MinPlyIndex IS NULL OR m.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR m.PlyIndex <= @MaxPlyIndex)
+                GROUP BY fg.GameId
+                HAVING COUNT(*) > 0
+            ),
+            PerGame AS
+            (
+                SELECT GameId,
+                       CAST(ForwardCount AS FLOAT) / MoveCount AS ForwardMoveRate
+                FROM PlayerMoves
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(ForwardMoveRate) AS AverageForwardMoveRate
+            FROM PerGame;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/ForwardMoveRateExecutor.cs
+++ b/src/Services/Analytics/ForwardMoveRateExecutor.cs
@@ -1,0 +1,42 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean per-game share of moves landing in the opponent's half (PLAN §12.6 Phase 4).
+/// </summary>
+public sealed class ForwardMoveRateExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "ForwardMoveRate";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetForwardMoveRateAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(ForwardMoveRateRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GameCount,
+                r.AverageForwardMoveRate
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GameCount", "AverageForwardMoveRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(ForwardMoveRateRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -139,6 +139,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<CentreMoveRateRow>>();
 
+    public Task<IReadOnlyList<ForwardMoveRateRow>> GetForwardMoveRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<ForwardMoveRateRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -60,6 +60,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CentreMoveRateRow>());
+        repo.Setup(r => r.GetForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ForwardMoveRateRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -77,7 +79,8 @@ public class MetricRegistryAndExecutorsTests
             new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator),
             new CaptureRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new CentreMoveRateExecutor(repo.Object)
+            new CentreMoveRateExecutor(repo.Object),
+            new ForwardMoveRateExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -95,7 +98,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("CaptureRate", sut.MetricKeys);
         Assert.Contains("QueenTradeRate", sut.MetricKeys);
         Assert.Contains("CentreMoveRate", sut.MetricKeys);
-        Assert.Equal(15, sut.MetricKeys.Count);
+        Assert.Contains("ForwardMoveRate", sut.MetricKeys);
+        Assert.Equal(16, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -1312,6 +1316,68 @@ public class MetricRegistryAndExecutorsTests
 
         repo.Verify(r => r.GetCentreMoveRateAsync(
             It.Is<AnalyticsQuery>(q => q.MinPlyIndex == 5 && q.MaxPlyIndex == 40),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ForwardMoveRateExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ForwardMoveRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Tal",
+                    PlayerForenames = "Mikhail",
+                    GameCount = 12,
+                    AverageForwardMoveRate = 0.48
+                }
+            });
+
+        var sut = new ForwardMoveRateExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail"
+        });
+
+        Assert.Equal(["Player", "GameCount", "AverageForwardMoveRate"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Tal, Mikhail", result.Rows[0][0]);
+        Assert.Equal(12, result.Rows[0][1]);
+        Assert.Equal(0.48, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task ForwardMoveRateExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new ForwardMoveRateExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task ForwardMoveRateExecutor_PassesPlyWindowToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ForwardMoveRateRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            MinPlyIndex = 8,
+            MaxPlyIndex = 35
+        };
+        var sut = new ForwardMoveRateExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetForwardMoveRateAsync(
+            It.Is<AnalyticsQuery>(q => q.MinPlyIndex == 8 && q.MaxPlyIndex == 35),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Add `ForwardMoveRate` — mean per-game share of a player's moves landing in the opponent's half (PLAN §12.6 Phase 4).
- White: `ToSquare` rank index ≥ 4; Black: rank index ≤ 3.
- Optional `minPlyIndex` / `maxPlyIndex` ply window; SQL, repository, executor, catalog, and tests.

## Test plan
- [x] `dotnet test` passes (including `ForwardMoveRateExecutor_*` tests)
- [ ] Run `ForwardMoveRate` for a known player against a populated DB
- [ ] Confirm metric appears in discovery UI and executes via HTTP
