### PR TITLE
feat: add CastlingSidePreference style metric

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`ForwardMoveRate` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`CastlingSidePreference` metric — PR in flight.)
 
 ---
 
@@ -29,7 +29,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (corpus benchmarks on main):** `AverageMaterialVolatility`, `AverageCastlingPly`, `BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate` (PR #56).
 - **Done (corpus benchmarks):** `QueenTradeRate` (PR #57).
 - **Done (Phase 4):** `CentreMoveRate` (PR #58).
-- **In flight:** `ForwardMoveRate` spatial metric (Phase 4).
+- **Done (Phase 4):** `ForwardMoveRate` (PR #59).
+- **In flight:** `CastlingSidePreference` (Phase 5).
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -49,9 +50,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next (after ForwardMoveRate PR merges):** [PLAN.md §12.6 Phase 5](./PLAN.md) — implement **`CastlingSidePreference`**.
+**Do next (after CastlingSidePreference PR merges):** [PLAN.md §12.6 Phase 5](./PLAN.md) — implement **`OppositeSideCastlingRate`**.
 
-**Then:** `OppositeSideCastlingRate` and Phase 6+ per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
+**Then:** `UncastledKingRate`, Phase 6+ per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -518,7 +518,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
 
 #### Phase 5 — king safety extensions
 
-9. [ ] **`CastlingSidePreference`**
+9. [x] **`CastlingSidePreference`**
    - **Data:** `GameMove` castling rows for the player.
    - **Per game:** first castle only — kingside vs queenside.
    - **Aggregate:** `KingsideRate`, `QueensideRate` (proportions among games with castling).

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -44,6 +44,8 @@ internal static class MetricCatalog
                 "Mean per-game share of the filtered player's moves landing on central squares d4, d5, e4, e5.",
             "ForwardMoveRate" =>
                 "Mean per-game share of the filtered player's moves landing in the opponent's half of the board.",
+            "CastlingSidePreference" =>
+                "Kingside vs queenside preference on the filtered player's first castle; rates are among games where the player castled.",
             _ => null
         };
     }
@@ -178,6 +180,13 @@ internal static class MetricCatalog
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional: minPlyIndex, maxPlyIndex to restrict which move plies count.",
                 "Forward for White means ToSquare rank index >= 4; for Black, rank index <= 3."
+            ],
+            "CastlingSidePreference" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "KingsideRate and QueensideRate sum to 1.0 among games with castling; games without castling are excluded."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -99,6 +99,7 @@ builder.Services.AddScoped<IMetricExecutor, CaptureRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, QueenTradeRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CentreMoveRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, ForwardMoveRateExecutor>();
+builder.Services.AddScoped<IMetricExecutor, CastlingSidePreferenceExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/CastlingSidePreferenceRow.cs
+++ b/src/Interfaces/Analytics/CastlingSidePreferenceRow.cs
@@ -1,0 +1,14 @@
+namespace Interfaces.Analytics;
+
+public sealed class CastlingSidePreferenceRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GamesWithCastling { get; init; }
+
+    public double? KingsideRate { get; init; }
+
+    public double? QueensideRate { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -233,6 +233,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Kingside vs queenside rates on the filtered player's first castle per game.
+        /// </summary>
+        Task<IReadOnlyList<CastlingSidePreferenceRow>> GetCastlingSidePreferenceAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1226,6 +1233,30 @@ namespace Repositories
                         Eco = NormalizeNonEmpty(query.Eco),
                         MinPlyIndex = query.MinPlyIndex,
                         MaxPlyIndex = query.MaxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<CastlingSidePreferenceRow>> GetCastlingSidePreferenceAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<CastlingSidePreferenceRow>(
+                new CommandDefinition(
+                    SqlStatements.GetCastlingSidePreference,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();
 

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1257,6 +1257,64 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Kingside vs queenside rates on the filtered player's first castle per game.
+        /// </summary>
+        public static string GetCastlingSidePreference =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            FirstCastlePly AS
+            (
+                SELECT fg.GameId,
+                       MIN(m.PlyIndex) AS CastlingPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND m.MovingSide = fg.PlayerSide
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                GROUP BY fg.GameId
+            ),
+            PerGame AS
+            (
+                SELECT fcp.GameId,
+                       CASE WHEN m.IsCastlingKingside = 1 THEN 1.0 ELSE 0.0 END AS IsKingside,
+                       CASE WHEN m.IsCastlingQueenside = 1 THEN 1.0 ELSE 0.0 END AS IsQueenside
+                FROM FirstCastlePly fcp
+                INNER JOIN FilteredGames fg ON fg.GameId = fcp.GameId
+                INNER JOIN dbo.GameMove m ON m.GameId = fcp.GameId AND m.PlyIndex = fcp.CastlingPly
+                WHERE m.MovingSide = fg.PlayerSide
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GamesWithCastling,
+                   AVG(IsKingside) AS KingsideRate,
+                   AVG(IsQueenside) AS QueensideRate
+            FROM PerGame;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/CastlingSidePreferenceExecutor.cs
+++ b/src/Services/Analytics/CastlingSidePreferenceExecutor.cs
@@ -1,0 +1,43 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Kingside vs queenside preference on the filtered player's first castle (PLAN §12.6 Phase 5).
+/// </summary>
+public sealed class CastlingSidePreferenceExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "CastlingSidePreference";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetCastlingSidePreferenceAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(CastlingSidePreferenceRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GamesWithCastling,
+                r.KingsideRate,
+                r.QueensideRate
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GamesWithCastling", "KingsideRate", "QueensideRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(CastlingSidePreferenceRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -143,6 +143,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<ForwardMoveRateRow>>();
 
+    public Task<IReadOnlyList<CastlingSidePreferenceRow>> GetCastlingSidePreferenceAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<CastlingSidePreferenceRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -62,6 +62,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<CentreMoveRateRow>());
         repo.Setup(r => r.GetForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<ForwardMoveRateRow>());
+        repo.Setup(r => r.GetCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CastlingSidePreferenceRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -80,7 +82,8 @@ public class MetricRegistryAndExecutorsTests
             new CaptureRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new CentreMoveRateExecutor(repo.Object),
-            new ForwardMoveRateExecutor(repo.Object)
+            new ForwardMoveRateExecutor(repo.Object),
+            new CastlingSidePreferenceExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -99,7 +102,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("QueenTradeRate", sut.MetricKeys);
         Assert.Contains("CentreMoveRate", sut.MetricKeys);
         Assert.Contains("ForwardMoveRate", sut.MetricKeys);
-        Assert.Equal(16, sut.MetricKeys.Count);
+        Assert.Contains("CastlingSidePreference", sut.MetricKeys);
+        Assert.Equal(17, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -1378,6 +1382,76 @@ public class MetricRegistryAndExecutorsTests
 
         repo.Verify(r => r.GetForwardMoveRateAsync(
             It.Is<AnalyticsQuery>(q => q.MinPlyIndex == 8 && q.MaxPlyIndex == 35),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CastlingSidePreferenceExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CastlingSidePreferenceRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GamesWithCastling = 80,
+                    KingsideRate = 0.75,
+                    QueensideRate = 0.25
+                }
+            });
+
+        var sut = new CastlingSidePreferenceExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly"
+        });
+
+        Assert.Equal(["Player", "GamesWithCastling", "KingsideRate", "QueensideRate"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Karpov, Anatoly", result.Rows[0][0]);
+        Assert.Equal(80, result.Rows[0][1]);
+        Assert.Equal(0.75, result.Rows[0][2]);
+        Assert.Equal(0.25, result.Rows[0][3]);
+    }
+
+    [Fact]
+    public async Task CastlingSidePreferenceExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new CastlingSidePreferenceExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task CastlingSidePreferenceExecutor_PassesFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CastlingSidePreferenceRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Petrosian",
+            PlayerForenames = "Tigran",
+            MinGameYear = 1960,
+            MaxGameYear = 1970,
+            Eco = "A30"
+        };
+        var sut = new CastlingSidePreferenceExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetCastlingSidePreferenceAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerSurname == "Petrosian"
+                && q.PlayerForenames == "Tigran"
+                && q.MinGameYear == 1960
+                && q.MaxGameYear == 1970
+                && q.Eco == "A30"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Add `CastlingSidePreference` — kingside vs queenside rates on the filtered player's first castle per game (PLAN §12.6 Phase 5).
- Uses `GameMove` castling flags; only games where the player castled are included.
- SQL, repository, executor, catalog hints, and unit tests.

## Test plan
- [x] `dotnet test` passes (including `CastlingSidePreferenceExecutor_*` tests)
- [ ] Run `CastlingSidePreference` for a known player against a populated DB
- [ ] Verify `KingsideRate` + `QueensideRate` ≈ 1.0 among castled games
