### PR TITLE
feat: add OppositeSideCastlingRate style metric

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`CastlingSidePreference` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`OppositeSideCastlingRate` metric — PR in flight.)
 
 ---
 
@@ -30,7 +30,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (corpus benchmarks):** `QueenTradeRate` (PR #57).
 - **Done (Phase 4):** `CentreMoveRate` (PR #58).
 - **Done (Phase 4):** `ForwardMoveRate` (PR #59).
-- **In flight:** `CastlingSidePreference` (Phase 5).
+- **Done (Phase 5):** `CastlingSidePreference` (PR #60).
+- **In flight:** `OppositeSideCastlingRate` (Phase 5).
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -50,9 +51,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next (after CastlingSidePreference PR merges):** [PLAN.md §12.6 Phase 5](./PLAN.md) — implement **`OppositeSideCastlingRate`**.
+**Do next (after OppositeSideCastlingRate PR merges):** [PLAN.md §12.6 Phase 5](./PLAN.md) — implement **`UncastledKingRate`**.
 
-**Then:** `UncastledKingRate`, Phase 6+ per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
+**Then:** Phase 6 (`FirstQueenMovePly`, …) per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -525,7 +525,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
    - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GamesWithCastling`, `KingsideRate`,
      `QueensideRate`.
 
-10. [ ] **`OppositeSideCastlingRate`**
+10. [x] **`OppositeSideCastlingRate`**
     - **Data:** first castling ply and side per colour per game from `GameMove`.
     - **Per game:** `1` if White and Black castled to different wings (kingside = K-side file,
       queenside = Q-side), else `0` (exclude games where either side never castled, or report

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -46,6 +46,8 @@ internal static class MetricCatalog
                 "Mean per-game share of the filtered player's moves landing in the opponent's half of the board.",
             "CastlingSidePreference" =>
                 "Kingside vs queenside preference on the filtered player's first castle; rates are among games where the player castled.",
+            "OppositeSideCastlingRate" =>
+                "Share of the filtered player's games where both sides castled to opposite wings (kingside vs queenside).",
             _ => null
         };
     }
@@ -187,6 +189,13 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
                 "KingsideRate and QueensideRate sum to 1.0 among games with castling; games without castling are excluded."
+            ],
+            "OppositeSideCastlingRate" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "EligibleGameCount counts games where both White and Black castled; others are excluded."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -100,6 +100,7 @@ builder.Services.AddScoped<IMetricExecutor, QueenTradeRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CentreMoveRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, ForwardMoveRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CastlingSidePreferenceExecutor>();
+builder.Services.AddScoped<IMetricExecutor, OppositeSideCastlingRateExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/OppositeSideCastlingRateRow.cs
+++ b/src/Interfaces/Analytics/OppositeSideCastlingRateRow.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.Analytics;
+
+public sealed class OppositeSideCastlingRateRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int EligibleGameCount { get; init; }
+
+    public double? OppositeSideCastlingRate { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -240,6 +240,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Proportion of filtered games where both sides castled to opposite wings.
+        /// </summary>
+        Task<IReadOnlyList<OppositeSideCastlingRateRow>> GetOppositeSideCastlingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1249,6 +1256,30 @@ namespace Repositories
             var rows = (await connection.QueryAsync<CastlingSidePreferenceRow>(
                 new CommandDefinition(
                     SqlStatements.GetCastlingSidePreference,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<OppositeSideCastlingRateRow>> GetOppositeSideCastlingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<OppositeSideCastlingRateRow>(
+                new CommandDefinition(
+                    SqlStatements.GetOppositeSideCastlingRate,
                     new
                     {
                         MinGameYear = query.MinGameYear,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1315,6 +1315,90 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Proportion of filtered games where White and Black each castled to opposite wings.
+        /// </summary>
+        public static string GetOppositeSideCastlingRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            WhiteFirstCastlePly AS
+            (
+                SELECT fg.GameId,
+                       MIN(m.PlyIndex) AS CastlingPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE m.MovingSide = 'W'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                GROUP BY fg.GameId
+            ),
+            WhiteCastle AS
+            (
+                SELECT wcp.GameId,
+                       m.IsCastlingKingside
+                FROM WhiteFirstCastlePly wcp
+                INNER JOIN dbo.GameMove m ON m.GameId = wcp.GameId AND m.PlyIndex = wcp.CastlingPly
+                WHERE m.MovingSide = 'W'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+            ),
+            BlackFirstCastlePly AS
+            (
+                SELECT fg.GameId,
+                       MIN(m.PlyIndex) AS CastlingPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE m.MovingSide = 'B'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                GROUP BY fg.GameId
+            ),
+            BlackCastle AS
+            (
+                SELECT bcp.GameId,
+                       m.IsCastlingKingside
+                FROM BlackFirstCastlePly bcp
+                INNER JOIN dbo.GameMove m ON m.GameId = bcp.GameId AND m.PlyIndex = bcp.CastlingPly
+                WHERE m.MovingSide = 'B'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+            ),
+            EligibleGames AS
+            (
+                SELECT fg.GameId,
+                       CASE
+                           WHEN wc.IsCastlingKingside <> bc.IsCastlingKingside THEN 1.0
+                           ELSE 0.0
+                       END AS IsOppositeSide
+                FROM FilteredGames fg
+                INNER JOIN WhiteCastle wc ON wc.GameId = fg.GameId
+                INNER JOIN BlackCastle bc ON bc.GameId = fg.GameId
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS EligibleGameCount,
+                   AVG(IsOppositeSide) AS OppositeSideCastlingRate
+            FROM EligibleGames;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -147,6 +147,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<CastlingSidePreferenceRow>>();
 
+    public Task<IReadOnlyList<OppositeSideCastlingRateRow>> GetOppositeSideCastlingRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<OppositeSideCastlingRateRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/src/Services/Analytics/OppositeSideCastlingRateExecutor.cs
+++ b/src/Services/Analytics/OppositeSideCastlingRateExecutor.cs
@@ -1,0 +1,42 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Share of filtered games where both sides castled to opposite wings (PLAN §12.6 Phase 5).
+/// </summary>
+public sealed class OppositeSideCastlingRateExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "OppositeSideCastlingRate";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetOppositeSideCastlingRateAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(OppositeSideCastlingRateRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.EligibleGameCount,
+                r.OppositeSideCastlingRate
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "EligibleGameCount", "OppositeSideCastlingRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(OppositeSideCastlingRateRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -64,6 +64,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<ForwardMoveRateRow>());
         repo.Setup(r => r.GetCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CastlingSidePreferenceRow>());
+        repo.Setup(r => r.GetOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<OppositeSideCastlingRateRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -83,7 +85,8 @@ public class MetricRegistryAndExecutorsTests
             new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new CentreMoveRateExecutor(repo.Object),
             new ForwardMoveRateExecutor(repo.Object),
-            new CastlingSidePreferenceExecutor(repo.Object)
+            new CastlingSidePreferenceExecutor(repo.Object),
+            new OppositeSideCastlingRateExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -103,7 +106,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("CentreMoveRate", sut.MetricKeys);
         Assert.Contains("ForwardMoveRate", sut.MetricKeys);
         Assert.Contains("CastlingSidePreference", sut.MetricKeys);
-        Assert.Equal(17, sut.MetricKeys.Count);
+        Assert.Contains("OppositeSideCastlingRate", sut.MetricKeys);
+        Assert.Equal(18, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -1452,6 +1456,74 @@ public class MetricRegistryAndExecutorsTests
                 && q.MinGameYear == 1960
                 && q.MaxGameYear == 1970
                 && q.Eco == "A30"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OppositeSideCastlingRateExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OppositeSideCastlingRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Tal",
+                    PlayerForenames = "Mikhail",
+                    EligibleGameCount = 50,
+                    OppositeSideCastlingRate = 0.4
+                }
+            });
+
+        var sut = new OppositeSideCastlingRateExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail"
+        });
+
+        Assert.Equal(["Player", "EligibleGameCount", "OppositeSideCastlingRate"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Tal, Mikhail", result.Rows[0][0]);
+        Assert.Equal(50, result.Rows[0][1]);
+        Assert.Equal(0.4, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task OppositeSideCastlingRateExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new OppositeSideCastlingRateExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task OppositeSideCastlingRateExecutor_PassesFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<OppositeSideCastlingRateRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            PlayerColour = "White",
+            MinGameYear = 1985,
+            MaxGameYear = 1995
+        };
+        var sut = new OppositeSideCastlingRateExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetOppositeSideCastlingRateAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerSurname == "Kasparov"
+                && q.PlayerForenames == "Garry"
+                && q.PlayerColour == "White"
+                && q.MinGameYear == 1985
+                && q.MaxGameYear == 1995),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Add `OppositeSideCastlingRate` — share of filtered games where both White and Black castled to opposite wings (PLAN §12.6 Phase 5).
- Only games where both sides castled are eligible (`EligibleGameCount`).
- SQL, repository, executor, catalog hints, and unit tests.

## Test plan
- [x] `dotnet test` passes (including `OppositeSideCastlingRateExecutor_*` tests)
- [ ] Run metric for a known aggressive player vs defensive player on a populated DB
- [ ] Confirm games with missing castling are excluded from the denominator
