### PR TITLE
feat: add UncastledKingRate style metric

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`OppositeSideCastlingRate` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`UncastledKingRate` metric — PR in flight.)
 
 ---
 
@@ -31,7 +31,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (Phase 4):** `CentreMoveRate` (PR #58).
 - **Done (Phase 4):** `ForwardMoveRate` (PR #59).
 - **Done (Phase 5):** `CastlingSidePreference` (PR #60).
-- **In flight:** `OppositeSideCastlingRate` (Phase 5).
+- **Done (Phase 5):** `OppositeSideCastlingRate` (PR #61).
+- **In flight:** `UncastledKingRate` (Phase 5 — completes king-safety extensions).
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -51,9 +52,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next (after OppositeSideCastlingRate PR merges):** [PLAN.md §12.6 Phase 5](./PLAN.md) — implement **`UncastledKingRate`**.
+**Do next (after UncastledKingRate PR merges):** [PLAN.md §12.6 Phase 6](./PLAN.md) — implement **`FirstQueenMovePly`**.
 
-**Then:** Phase 6 (`FirstQueenMovePly`, …) per PLAN; corpus benchmarks on Phase 4 metrics as follow-up PRs.
+**Then:** Phase 6+ per PLAN; corpus benchmarks on Phase 4–5 metrics as follow-up PRs.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -533,7 +533,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
     - **Aggregate:** proportion over eligible games.
     - **Result columns:** `EligibleGameCount`, `OppositeSideCastlingRate`.
 
-11. [ ] **`UncastledKingRate`**
+11. [x] **`UncastledKingRate`**
     - **Per game:** `1` if the filtered player never castled, else `0`.
     - **Aggregate:** proportion.
     - **Result columns:** `GameCount`, `UncastledKingRate`.

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -48,6 +48,8 @@ internal static class MetricCatalog
                 "Kingside vs queenside preference on the filtered player's first castle; rates are among games where the player castled.",
             "OppositeSideCastlingRate" =>
                 "Share of the filtered player's games where both sides castled to opposite wings (kingside vs queenside).",
+            "UncastledKingRate" =>
+                "Proportion of the filtered player's games where they never castled.",
             _ => null
         };
     }
@@ -196,6 +198,13 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
                 "EligibleGameCount counts games where both White and Black castled; others are excluded."
+            ],
+            "UncastledKingRate" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "GameCount is all filtered appearances; UncastledKingRate is the share with no castling move."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -101,6 +101,7 @@ builder.Services.AddScoped<IMetricExecutor, CentreMoveRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, ForwardMoveRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CastlingSidePreferenceExecutor>();
 builder.Services.AddScoped<IMetricExecutor, OppositeSideCastlingRateExecutor>();
+builder.Services.AddScoped<IMetricExecutor, UncastledKingRateExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/UncastledKingRateRow.cs
+++ b/src/Interfaces/Analytics/UncastledKingRateRow.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.Analytics;
+
+public sealed class UncastledKingRateRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? UncastledKingRate { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -247,6 +247,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Proportion of filtered games where the player never castled.
+        /// </summary>
+        Task<IReadOnlyList<UncastledKingRateRow>> GetUncastledKingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1280,6 +1287,30 @@ namespace Repositories
             var rows = (await connection.QueryAsync<OppositeSideCastlingRateRow>(
                 new CommandDefinition(
                     SqlStatements.GetOppositeSideCastlingRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<UncastledKingRateRow>> GetUncastledKingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<UncastledKingRateRow>(
+                new CommandDefinition(
+                    SqlStatements.GetUncastledKingRate,
                     new
                     {
                         MinGameYear = query.MinGameYear,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1399,6 +1399,57 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Proportion of filtered games where the player never castled.
+        /// </summary>
+        public static string GetUncastledKingRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            PerGame AS
+            (
+                SELECT fg.GameId,
+                       CASE
+                           WHEN EXISTS (
+                               SELECT 1
+                               FROM dbo.GameMove m
+                               WHERE m.GameId = fg.GameId
+                                 AND m.MovingSide = fg.PlayerSide
+                                 AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                           ) THEN 0.0
+                           ELSE 1.0
+                       END AS IsUncastled
+                FROM FilteredGames fg
+                WHERE fg.PlayerSide IS NOT NULL
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(IsUncastled) AS UncastledKingRate
+            FROM PerGame;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -151,6 +151,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<OppositeSideCastlingRateRow>>();
 
+    public Task<IReadOnlyList<UncastledKingRateRow>> GetUncastledKingRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<UncastledKingRateRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/src/Services/Analytics/UncastledKingRateExecutor.cs
+++ b/src/Services/Analytics/UncastledKingRateExecutor.cs
@@ -1,0 +1,42 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Proportion of filtered games where the player never castled (PLAN §12.6 Phase 5).
+/// </summary>
+public sealed class UncastledKingRateExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "UncastledKingRate";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetUncastledKingRateAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(UncastledKingRateRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GameCount,
+                r.UncastledKingRate
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GameCount", "UncastledKingRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(UncastledKingRateRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -66,6 +66,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<CastlingSidePreferenceRow>());
         repo.Setup(r => r.GetOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<OppositeSideCastlingRateRow>());
+        repo.Setup(r => r.GetUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UncastledKingRateRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -86,7 +88,8 @@ public class MetricRegistryAndExecutorsTests
             new CentreMoveRateExecutor(repo.Object),
             new ForwardMoveRateExecutor(repo.Object),
             new CastlingSidePreferenceExecutor(repo.Object),
-            new OppositeSideCastlingRateExecutor(repo.Object)
+            new OppositeSideCastlingRateExecutor(repo.Object),
+            new UncastledKingRateExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -107,7 +110,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("ForwardMoveRate", sut.MetricKeys);
         Assert.Contains("CastlingSidePreference", sut.MetricKeys);
         Assert.Contains("OppositeSideCastlingRate", sut.MetricKeys);
-        Assert.Equal(18, sut.MetricKeys.Count);
+        Assert.Contains("UncastledKingRate", sut.MetricKeys);
+        Assert.Equal(19, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -1524,6 +1528,72 @@ public class MetricRegistryAndExecutorsTests
                 && q.PlayerColour == "White"
                 && q.MinGameYear == 1985
                 && q.MaxGameYear == 1995),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UncastledKingRateExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UncastledKingRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Fischer",
+                    PlayerForenames = "Robert James",
+                    GameCount = 100,
+                    UncastledKingRate = 0.05
+                }
+            });
+
+        var sut = new UncastledKingRateExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Fischer",
+            PlayerForenames = "Robert James"
+        });
+
+        Assert.Equal(["Player", "GameCount", "UncastledKingRate"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Fischer, Robert James", result.Rows[0][0]);
+        Assert.Equal(100, result.Rows[0][1]);
+        Assert.Equal(0.05, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task UncastledKingRateExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new UncastledKingRateExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task UncastledKingRateExecutor_PassesFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UncastledKingRateRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail",
+            Eco = "B90",
+            MinGameYear = 1960
+        };
+        var sut = new UncastledKingRateExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetUncastledKingRateAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerSurname == "Tal"
+                && q.PlayerForenames == "Mikhail"
+                && q.Eco == "B90"
+                && q.MinGameYear == 1960),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Add `UncastledKingRate` — proportion of filtered games where the player never castled (PLAN §12.6 Phase 5).
- Completes Phase 5 king-safety extensions alongside `CastlingSidePreference` and `OppositeSideCastlingRate`.
- SQL, repository, executor, catalog hints, and unit tests.

## Test plan
- [x] `dotnet test` passes (including `UncastledKingRateExecutor_*` tests)
- [ ] Run metric for a known rarely-castling player vs a frequent caster on a populated DB
- [ ] Confirm `GameCount` matches other style metrics on the same filters
