### PR TITLE
feat: add FirstQueenMovePly style metric

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`UncastledKingRate` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`FirstQueenMovePly` metric — PR in flight.)
 
 ---
 
@@ -32,7 +32,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (Phase 4):** `ForwardMoveRate` (PR #59).
 - **Done (Phase 5):** `CastlingSidePreference` (PR #60).
 - **Done (Phase 5):** `OppositeSideCastlingRate` (PR #61).
-- **In flight:** `UncastledKingRate` (Phase 5 — completes king-safety extensions).
+- **Done (Phase 5):** `UncastledKingRate` (PR #62).
+- **In flight:** `FirstQueenMovePly` (Phase 6).
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -52,9 +53,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next (after UncastledKingRate PR merges):** [PLAN.md §12.6 Phase 6](./PLAN.md) — implement **`FirstQueenMovePly`**.
+**Do next (after FirstQueenMovePly PR merges):** [PLAN.md §12.6 Phase 7](./PLAN.md) — implement **`AverageGameLength`**.
 
-**Then:** Phase 6+ per PLAN; corpus benchmarks on Phase 4–5 metrics as follow-up PRs.
+**Then:** `ShortDrawRate` and Phase 7+ per PLAN; corpus benchmarks on Phase 4–5 metrics as follow-up PRs.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -542,7 +542,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
 
 #### Phase 6 — queen timing
 
-12. [ ] **`FirstQueenMovePly`**
+12. [x] **`FirstQueenMovePly`**
     - **Data:** `GameMove` where `MovedPiece = 'Q'` for the player's side.
     - **Per game:** `MIN(PlyIndex)` of queen moves; normalize optionally as
       `first_queen_ply / max_ply` (document if normalization is included — v1 can report raw ply).

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -50,6 +50,8 @@ internal static class MetricCatalog
                 "Share of the filtered player's games where both sides castled to opposite wings (kingside vs queenside).",
             "UncastledKingRate" =>
                 "Proportion of the filtered player's games where they never castled.",
+            "FirstQueenMovePly" =>
+                "Mean half-move ply of the filtered player's first queen move; games without a queen move are excluded.",
             _ => null
         };
     }
@@ -205,6 +207,13 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
                 "GameCount is all filtered appearances; UncastledKingRate is the share with no castling move."
+            ],
+            "FirstQueenMovePly" =>
+            [
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "GamesWithQueenMove counts games where the queen moved at least once; average is raw ply (not normalized by game length)."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -102,6 +102,7 @@ builder.Services.AddScoped<IMetricExecutor, ForwardMoveRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, CastlingSidePreferenceExecutor>();
 builder.Services.AddScoped<IMetricExecutor, OppositeSideCastlingRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, UncastledKingRateExecutor>();
+builder.Services.AddScoped<IMetricExecutor, FirstQueenMovePlyExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Interfaces/Analytics/FirstQueenMovePlyRow.cs
+++ b/src/Interfaces/Analytics/FirstQueenMovePlyRow.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.Analytics;
+
+public sealed class FirstQueenMovePlyRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GamesWithQueenMove { get; init; }
+
+    public double? AverageFirstQueenMovePly { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -254,6 +254,13 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Mean ply of the filtered player's first queen move.
+        /// </summary>
+        Task<IReadOnlyList<FirstQueenMovePlyRow>> GetFirstQueenMovePlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1311,6 +1318,30 @@ namespace Repositories
             var rows = (await connection.QueryAsync<UncastledKingRateRow>(
                 new CommandDefinition(
                     SqlStatements.GetUncastledKingRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<FirstQueenMovePlyRow>> GetFirstQueenMovePlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<FirstQueenMovePlyRow>(
+                new CommandDefinition(
+                    SqlStatements.GetFirstQueenMovePly,
                     new
                     {
                         MinGameYear = query.MinGameYear,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1450,6 +1450,52 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Mean ply of the filtered player's first queen move; games without a queen move are excluded.
+        /// </summary>
+        public static string GetFirstQueenMovePly =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            FirstQueenMove AS
+            (
+                SELECT fg.GameId,
+                       MIN(m.PlyIndex) AS FirstQueenPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND m.MovingSide = fg.PlayerSide
+                  AND m.MovedPiece = 'Q'
+                GROUP BY fg.GameId
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GamesWithQueenMove,
+                   AVG(CAST(FirstQueenPly AS FLOAT)) AS AverageFirstQueenMovePly
+            FROM FirstQueenMove;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/FirstQueenMovePlyExecutor.cs
+++ b/src/Services/Analytics/FirstQueenMovePlyExecutor.cs
@@ -1,0 +1,42 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean ply of the filtered player's first queen move (PLAN §12.6 Phase 6).
+/// </summary>
+public sealed class FirstQueenMovePlyExecutor(IChessRepository repository) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    public string MetricKey => "FirstQueenMovePly";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = await _repository.GetFirstQueenMovePlyAsync(query, cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<object?> Row(FirstQueenMovePlyRow r) =>
+            new object?[]
+            {
+                FormatPlayer(r),
+                r.GamesWithQueenMove,
+                r.AverageFirstQueenMovePly
+            };
+
+        return new AnalyticsTableResult
+        {
+            ColumnNames = ["Player", "GamesWithQueenMove", "AverageFirstQueenMovePly"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
+        };
+    }
+
+    private static string FormatPlayer(FirstQueenMovePlyRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -155,6 +155,10 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<UncastledKingRateRow>>();
 
+    public Task<IReadOnlyList<FirstQueenMovePlyRow>> GetFirstQueenMovePlyAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<FirstQueenMovePlyRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -68,6 +68,8 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<OppositeSideCastlingRateRow>());
         repo.Setup(r => r.GetUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UncastledKingRateRow>());
+        repo.Setup(r => r.GetFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<FirstQueenMovePlyRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -89,7 +91,8 @@ public class MetricRegistryAndExecutorsTests
             new ForwardMoveRateExecutor(repo.Object),
             new CastlingSidePreferenceExecutor(repo.Object),
             new OppositeSideCastlingRateExecutor(repo.Object),
-            new UncastledKingRateExecutor(repo.Object)
+            new UncastledKingRateExecutor(repo.Object),
+            new FirstQueenMovePlyExecutor(repo.Object)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -111,7 +114,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("CastlingSidePreference", sut.MetricKeys);
         Assert.Contains("OppositeSideCastlingRate", sut.MetricKeys);
         Assert.Contains("UncastledKingRate", sut.MetricKeys);
-        Assert.Equal(19, sut.MetricKeys.Count);
+        Assert.Contains("FirstQueenMovePly", sut.MetricKeys);
+        Assert.Equal(20, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -1594,6 +1598,72 @@ public class MetricRegistryAndExecutorsTests
                 && q.PlayerForenames == "Mikhail"
                 && q.Eco == "B90"
                 && q.MinGameYear == 1960),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FirstQueenMovePlyExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<FirstQueenMovePlyRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Kasparov",
+                    PlayerForenames = "Garry",
+                    GamesWithQueenMove = 45,
+                    AverageFirstQueenMovePly = 6.5
+                }
+            });
+
+        var sut = new FirstQueenMovePlyExecutor(repo.Object);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry"
+        });
+
+        Assert.Equal(["Player", "GamesWithQueenMove", "AverageFirstQueenMovePly"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Kasparov, Garry", result.Rows[0][0]);
+        Assert.Equal(45, result.Rows[0][1]);
+        Assert.Equal(6.5, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task FirstQueenMovePlyExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new FirstQueenMovePlyExecutor(repo.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task FirstQueenMovePlyExecutor_PassesFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<FirstQueenMovePlyRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Petrosian",
+            PlayerForenames = "Tigran",
+            PlayerColour = "Black",
+            MaxGameYear = 1975
+        };
+        var sut = new FirstQueenMovePlyExecutor(repo.Object);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetFirstQueenMovePlyAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerSurname == "Petrosian"
+                && q.PlayerForenames == "Tigran"
+                && q.PlayerColour == "Black"
+                && q.MaxGameYear == 1975),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Add `FirstQueenMovePly` — mean half-move ply of the filtered player's first queen move (PLAN §12.6 Phase 6).
- Games where the queen never moved are excluded from the average.
- SQL, repository, executor, catalog hints, and unit tests.

## Test plan
- [x] `dotnet test` passes (including `FirstQueenMovePlyExecutor_*` tests)
- [ ] Run metric for an early-queen-move player vs a late developer on a populated DB
- [ ] Confirm `GamesWithQueenMove` is less than or equal to total filtered game count
