### PR TITLE
feat: add corpus benchmarks for remaining style metrics

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -33,7 +33,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (Phase 5):** `CastlingSidePreference` (PR #60).
 - **Done (Phase 5):** `OppositeSideCastlingRate` (PR #61).
 - **Done (Phase 5):** `UncastledKingRate` (PR #62).
-- **In flight:** `FirstQueenMovePly` (Phase 6).
+- **Done (Phase 6):** `FirstQueenMovePly`.
+- **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -53,9 +54,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next (after FirstQueenMovePly PR merges):** [PLAN.md §12.6 Phase 7](./PLAN.md) — implement **`AverageGameLength`**.
+**Do next:** [PLAN.md §12.6 Phase 7](./PLAN.md) — implement **`AverageGameLength`**.
 
-**Then:** `ShortDrawRate` and Phase 7+ per PLAN; corpus benchmarks on Phase 4–5 metrics as follow-up PRs.
+**Then:** `ShortDrawRate` and Phase 7+ per PLAN.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -662,6 +662,8 @@ handling in tests.
 5. [x] **`AverageCastlingPly` + benchmark**
 6. [x] **Docs pass** — [STYLE_METRICS.md](./STYLE_METRICS.md) §8, `AGENT_CONTEXT.md`, example
    showing Fischer row with corpus columns.
+7. [x] **Phase 4–6 style metrics + benchmark** — `CentreMoveRate`, `ForwardMoveRate`,
+   `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`.
 
 **Result columns when benchmark enabled** (append to existing subject row):
 

--- a/docs/STYLE_METRICS.md
+++ b/docs/STYLE_METRICS.md
@@ -194,7 +194,9 @@ adding **corpus-relative benchmarks** ([DESIGN.md §12](./DESIGN.md), [PLAN.md �
 - Opt in with `includeCorpusBenchmark: true` on the metric query until defaults change.
 
 **Metrics with corpus benchmarks (v1):** `AverageMaterialVolatility`, `AverageCastlingPly`,
-`BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate`. (`QueenTradeRate` — follow-up PR.)
+`BishopPairFrequency`, `MinorPieceComposition`, `CaptureRate`, `QueenTradeRate`, `CentreMoveRate`,
+`ForwardMoveRate`, `CastlingSidePreference` (benchmarks `KingsideRate`), `OppositeSideCastlingRate`,
+`UncastledKingRate`, `FirstQueenMovePly`.
 
 Phase 3+ style metrics should ship with benchmark support where possible so new scalars are not
 published without context.

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -45,7 +45,7 @@ internal static class MetricCatalog
             "ForwardMoveRate" =>
                 "Mean per-game share of the filtered player's moves landing in the opponent's half of the board.",
             "CastlingSidePreference" =>
-                "Kingside vs queenside preference on the filtered player's first castle; rates are among games where the player castled.",
+                "Kingside vs queenside preference on the filtered player's first castle; rates are among games where the player castled. Corpus benchmarks compare KingsideRate.",
             "OppositeSideCastlingRate" =>
                 "Share of the filtered player's games where both sides castled to opposite wings (kingside vs queenside).",
             "UncastledKingRate" =>
@@ -177,7 +177,9 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional: minPlyIndex, maxPlyIndex to restrict which move plies count.",
-                "Centre squares are d4, d5, e4, e5 (ToSquare 27, 28, 35, 36)."
+                "Centre squares are d4, d5, e4, e5 (ToSquare 27, 28, 35, 36).",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "ForwardMoveRate" =>
             [
@@ -185,35 +187,45 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional: minPlyIndex, maxPlyIndex to restrict which move plies count.",
-                "Forward for White means ToSquare rank index >= 4; for Black, rank index <= 3."
+                "Forward for White means ToSquare rank index >= 4; for Black, rank index <= 3.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "CastlingSidePreference" =>
             [
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "KingsideRate and QueensideRate sum to 1.0 among games with castling; games without castling are excluded."
+                "KingsideRate and QueensideRate sum to 1.0 among games with castling; games without castling are excluded.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount (benchmarks KingsideRate).",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "OppositeSideCastlingRate" =>
             [
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "EligibleGameCount counts games where both White and Black castled; others are excluded."
+                "EligibleGameCount counts games where both White and Black castled; others are excluded.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "UncastledKingRate" =>
             [
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "GameCount is all filtered appearances; UncastledKingRate is the share with no castling move."
+                "GameCount is all filtered appearances; UncastledKingRate is the share with no castling move.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             "FirstQueenMovePly" =>
             [
                 "Required: playerSurname (playerForenames optional but recommended).",
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
-                "GamesWithQueenMove counts games where the queen moved at least once; average is raw ply (not normalized by game length)."
+                "GamesWithQueenMove counts games where the queen moved at least once; average is raw ply (not normalized by game length).",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             _ => []
         };

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -424,7 +424,13 @@
         BishopPairFrequency: true,
         MinorPieceComposition: true,
         CaptureRate: true,
-        QueenTradeRate: true
+        QueenTradeRate: true,
+        CentreMoveRate: true,
+        ForwardMoveRate: true,
+        CastlingSidePreference: true,
+        OppositeSideCastlingRate: true,
+        UncastledKingRate: true,
+        FirstQueenMovePly: true
       };
 
       function selectedMetricKey() {

--- a/src/Interfaces/Analytics/CastlingSidePreferenceRow.cs
+++ b/src/Interfaces/Analytics/CastlingSidePreferenceRow.cs
@@ -11,4 +11,12 @@ public sealed class CastlingSidePreferenceRow
     public double? KingsideRate { get; init; }
 
     public double? QueensideRate { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Interfaces/Analytics/CentreMoveRateRow.cs
+++ b/src/Interfaces/Analytics/CentreMoveRateRow.cs
@@ -9,4 +9,12 @@ public sealed class CentreMoveRateRow
     public int GameCount { get; init; }
 
     public double? AverageCentreMoveRate { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Interfaces/Analytics/FirstQueenMovePlyRow.cs
+++ b/src/Interfaces/Analytics/FirstQueenMovePlyRow.cs
@@ -9,4 +9,12 @@ public sealed class FirstQueenMovePlyRow
     public int GamesWithQueenMove { get; init; }
 
     public double? AverageFirstQueenMovePly { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Interfaces/Analytics/ForwardMoveRateRow.cs
+++ b/src/Interfaces/Analytics/ForwardMoveRateRow.cs
@@ -9,4 +9,12 @@ public sealed class ForwardMoveRateRow
     public int GameCount { get; init; }
 
     public double? AverageForwardMoveRate { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Interfaces/Analytics/OppositeSideCastlingRateRow.cs
+++ b/src/Interfaces/Analytics/OppositeSideCastlingRateRow.cs
@@ -9,4 +9,12 @@ public sealed class OppositeSideCastlingRateRow
     public int EligibleGameCount { get; init; }
 
     public double? OppositeSideCastlingRate { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Interfaces/Analytics/UncastledKingRateRow.cs
+++ b/src/Interfaces/Analytics/UncastledKingRateRow.cs
@@ -9,4 +9,12 @@ public sealed class UncastledKingRateRow
     public int GameCount { get; init; }
 
     public double? UncastledKingRate { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
 }

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -226,9 +226,23 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player mean centre-move rate aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerCentreMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Mean per-game share of moves landing in the opponent's half.
         /// </summary>
         Task<IReadOnlyList<ForwardMoveRateRow>> GetForwardMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Per-player mean forward-move rate aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerForwardMoveRateAsync(
             AnalyticsQuery query,
             CancellationToken cancellationToken = default);
 
@@ -240,9 +254,23 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player kingside castling preference aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerCastlingSidePreferenceAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Proportion of filtered games where both sides castled to opposite wings.
         /// </summary>
         Task<IReadOnlyList<OppositeSideCastlingRateRow>> GetOppositeSideCastlingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Per-player opposite-side castling rate aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerOppositeSideCastlingRateAsync(
             AnalyticsQuery query,
             CancellationToken cancellationToken = default);
 
@@ -254,9 +282,23 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Per-player uncastled-king rate aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerUncastledKingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Mean ply of the filtered player's first queen move.
         /// </summary>
         Task<IReadOnlyList<FirstQueenMovePlyRow>> GetFirstQueenMovePlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Per-player mean first queen move ply aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerFirstQueenMovePlyAsync(
             AnalyticsQuery query,
             CancellationToken cancellationToken = default);
 
@@ -1235,6 +1277,30 @@ namespace Repositories
         }
 
         /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerCentreMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerCentreMoveRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = query.MinPlyIndex,
+                        MaxPlyIndex = query.MaxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
         public async Task<IReadOnlyList<ForwardMoveRateRow>> GetForwardMoveRateAsync(
             AnalyticsQuery query,
             CancellationToken cancellationToken = default)
@@ -1250,6 +1316,30 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        MinPlyIndex = query.MinPlyIndex,
+                        MaxPlyIndex = query.MaxPlyIndex
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerForwardMoveRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerForwardMoveRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco),
                         MinPlyIndex = query.MinPlyIndex,
@@ -1285,6 +1375,28 @@ namespace Repositories
         }
 
         /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerCastlingSidePreferenceAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerCastlingSidePreference,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
         public async Task<IReadOnlyList<OppositeSideCastlingRateRow>> GetOppositeSideCastlingRateAsync(
             AnalyticsQuery query,
             CancellationToken cancellationToken = default)
@@ -1300,6 +1412,28 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerOppositeSideCastlingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerOppositeSideCastlingRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },
@@ -1333,6 +1467,28 @@ namespace Repositories
         }
 
         /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerUncastledKingRateAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerUncastledKingRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
         public async Task<IReadOnlyList<FirstQueenMovePlyRow>> GetFirstQueenMovePlyAsync(
             AnalyticsQuery query,
             CancellationToken cancellationToken = default)
@@ -1348,6 +1504,28 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
                         PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerFirstQueenMovePlyAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerFirstQueenMovePly,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
                     },

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1496,6 +1496,445 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Per-player mean centre-move rate for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerCentreMoveRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            PlayerMoves AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       SUM(CASE WHEN m.ToSquare IN (27, 28, 35, 36) THEN 1 ELSE 0 END) AS CentreCount,
+                       COUNT(*) AS MoveCount
+                FROM Appearances a
+                INNER JOIN dbo.GameMove m ON m.GameId = a.GameId
+                WHERE m.MovingSide = a.PlayerSide
+                  AND (@MinPlyIndex IS NULL OR m.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR m.PlyIndex <= @MaxPlyIndex)
+                GROUP BY a.PlayerSurname, a.PlayerForenames, a.GameId
+                HAVING COUNT(*) > 0
+            ),
+            PerGame AS
+            (
+                SELECT PlayerSurname,
+                       PlayerForenames,
+                       GameId,
+                       CAST(CentreCount AS FLOAT) / MoveCount AS CentreMoveRate
+                FROM PlayerMoves
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(CentreMoveRate) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
+        /// Per-player mean forward-move rate for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerForwardMoveRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            PlayerMoves AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       SUM(CASE
+                               WHEN m.MovingSide = 'W' AND (m.ToSquare / 8) >= 4 THEN 1
+                               WHEN m.MovingSide = 'B' AND (m.ToSquare / 8) <= 3 THEN 1
+                               ELSE 0
+                           END) AS ForwardCount,
+                       COUNT(*) AS MoveCount
+                FROM Appearances a
+                INNER JOIN dbo.GameMove m ON m.GameId = a.GameId
+                WHERE m.MovingSide = a.PlayerSide
+                  AND (@MinPlyIndex IS NULL OR m.PlyIndex >= @MinPlyIndex)
+                  AND (@MaxPlyIndex IS NULL OR m.PlyIndex <= @MaxPlyIndex)
+                GROUP BY a.PlayerSurname, a.PlayerForenames, a.GameId
+                HAVING COUNT(*) > 0
+            ),
+            PerGame AS
+            (
+                SELECT PlayerSurname,
+                       PlayerForenames,
+                       GameId,
+                       CAST(ForwardCount AS FLOAT) / MoveCount AS ForwardMoveRate
+                FROM PlayerMoves
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(ForwardMoveRate) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
+        /// Per-player kingside castling preference for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerCastlingSidePreference =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            FirstCastlePly AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       MIN(m.PlyIndex) AS CastlingPly
+                FROM Appearances a
+                INNER JOIN dbo.GameMove m ON m.GameId = a.GameId
+                WHERE m.MovingSide = a.PlayerSide
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                GROUP BY a.PlayerSurname, a.PlayerForenames, a.GameId
+            ),
+            PerGame AS
+            (
+                SELECT fcp.PlayerSurname,
+                       fcp.PlayerForenames,
+                       fcp.GameId,
+                       CASE WHEN m.IsCastlingKingside = 1 THEN 1.0 ELSE 0.0 END AS IsKingside
+                FROM FirstCastlePly fcp
+                INNER JOIN Appearances a ON a.GameId = fcp.GameId
+                    AND a.PlayerSurname = fcp.PlayerSurname
+                    AND ((a.PlayerForenames IS NULL AND fcp.PlayerForenames IS NULL) OR a.PlayerForenames = fcp.PlayerForenames)
+                INNER JOIN dbo.GameMove m ON m.GameId = fcp.GameId AND m.PlyIndex = fcp.CastlingPly
+                WHERE m.MovingSide = a.PlayerSide
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(IsKingside) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
+        /// Per-player opposite-side castling rate for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerOppositeSideCastlingRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            WhiteFirstCastlePly AS
+            (
+                SELECT fg.GameId,
+                       MIN(m.PlyIndex) AS CastlingPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE m.MovingSide = 'W'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                GROUP BY fg.GameId
+            ),
+            WhiteCastle AS
+            (
+                SELECT wcp.GameId,
+                       m.IsCastlingKingside
+                FROM WhiteFirstCastlePly wcp
+                INNER JOIN dbo.GameMove m ON m.GameId = wcp.GameId AND m.PlyIndex = wcp.CastlingPly
+                WHERE m.MovingSide = 'W'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+            ),
+            BlackFirstCastlePly AS
+            (
+                SELECT fg.GameId,
+                       MIN(m.PlyIndex) AS CastlingPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GameMove m ON m.GameId = fg.GameId
+                WHERE m.MovingSide = 'B'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                GROUP BY fg.GameId
+            ),
+            BlackCastle AS
+            (
+                SELECT bcp.GameId,
+                       m.IsCastlingKingside
+                FROM BlackFirstCastlePly bcp
+                INNER JOIN dbo.GameMove m ON m.GameId = bcp.GameId AND m.PlyIndex = bcp.CastlingPly
+                WHERE m.MovingSide = 'B'
+                  AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+            ),
+            EligibleGames AS
+            (
+                SELECT fg.GameId,
+                       CASE
+                           WHEN wc.IsCastlingKingside <> bc.IsCastlingKingside THEN 1.0
+                           ELSE 0.0
+                       END AS IsOppositeSide
+                FROM FilteredGames fg
+                INNER JOIN WhiteCastle wc ON wc.GameId = fg.GameId
+                INNER JOIN BlackCastle bc ON bc.GameId = fg.GameId
+            ),
+            PerGame AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       eg.IsOppositeSide
+                FROM Appearances a
+                INNER JOIN EligibleGames eg ON eg.GameId = a.GameId
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(IsOppositeSide) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
+        /// Per-player uncastled-king rate for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerUncastledKingRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            PerGame AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       CASE
+                           WHEN EXISTS (
+                               SELECT 1
+                               FROM dbo.GameMove m
+                               WHERE m.GameId = a.GameId
+                                 AND m.MovingSide = a.PlayerSide
+                                 AND (m.IsCastlingKingside = 1 OR m.IsCastlingQueenside = 1)
+                           ) THEN 0.0
+                           ELSE 1.0
+                       END AS IsUncastled
+                FROM Appearances a
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(IsUncastled) AS MetricValue
+            FROM PerGame
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
+        /// Per-player mean first queen move ply for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerFirstQueenMovePly =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames,
+                       CAST('W' AS CHAR(1)) AS PlayerSide
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames,
+                       CAST('B' AS CHAR(1))
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            FirstQueenMove AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       MIN(m.PlyIndex) AS FirstQueenPly
+                FROM Appearances a
+                INNER JOIN dbo.GameMove m ON m.GameId = a.GameId
+                WHERE m.MovingSide = a.PlayerSide
+                  AND m.MovedPiece = 'Q'
+                GROUP BY a.PlayerSurname, a.PlayerForenames, a.GameId
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(CAST(FirstQueenPly AS FLOAT)) AS MetricValue
+            FROM FirstQueenMove
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/CastlingSidePreferenceExecutor.cs
+++ b/src/Services/Analytics/CastlingSidePreferenceExecutor.cs
@@ -6,31 +6,98 @@ namespace Services.Analytics;
 /// <summary>
 /// Kingside vs queenside preference on the filtered player's first castle (PLAN §12.6 Phase 5).
 /// </summary>
-public sealed class CastlingSidePreferenceExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class CastlingSidePreferenceExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "CastlingSidePreference";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetCastlingSidePreferenceAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetCastlingSidePreferenceAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(CastlingSidePreferenceRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerCastlingSidePreferenceAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GamesWithCastling", "KingsideRate", "QueensideRate",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GamesWithCastling", "KingsideRate", "QueensideRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private CastlingSidePreferenceRow EnrichWithBenchmark(
+        CastlingSidePreferenceRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.KingsideRate,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new CastlingSidePreferenceRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GamesWithCastling = row.GamesWithCastling,
+            KingsideRate = row.KingsideRate,
+            QueensideRate = row.QueensideRate,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(CastlingSidePreferenceRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GamesWithCastling,
                 r.KingsideRate,
                 r.QueensideRate
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GamesWithCastling", "KingsideRate", "QueensideRate"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GamesWithCastling,
+            r.KingsideRate,
+            r.QueensideRate,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(CastlingSidePreferenceRow row)

--- a/src/Services/Analytics/CentreMoveRateExecutor.cs
+++ b/src/Services/Analytics/CentreMoveRateExecutor.cs
@@ -6,30 +6,95 @@ namespace Services.Analytics;
 /// <summary>
 /// Mean per-game share of moves landing on central squares d4, d5, e4, e5 (PLAN §12.6 Phase 4).
 /// </summary>
-public sealed class CentreMoveRateExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class CentreMoveRateExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "CentreMoveRate";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetCentreMoveRateAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetCentreMoveRateAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(CentreMoveRateRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerCentreMoveRateAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "AverageCentreMoveRate",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "AverageCentreMoveRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private CentreMoveRateRow EnrichWithBenchmark(
+        CentreMoveRateRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageCentreMoveRate,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new CentreMoveRateRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            AverageCentreMoveRate = row.AverageCentreMoveRate,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(CentreMoveRateRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GameCount,
                 r.AverageCentreMoveRate
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GameCount", "AverageCentreMoveRate"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.AverageCentreMoveRate,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(CentreMoveRateRow row)

--- a/src/Services/Analytics/FirstQueenMovePlyExecutor.cs
+++ b/src/Services/Analytics/FirstQueenMovePlyExecutor.cs
@@ -6,30 +6,95 @@ namespace Services.Analytics;
 /// <summary>
 /// Mean ply of the filtered player's first queen move (PLAN §12.6 Phase 6).
 /// </summary>
-public sealed class FirstQueenMovePlyExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class FirstQueenMovePlyExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "FirstQueenMovePly";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetFirstQueenMovePlyAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetFirstQueenMovePlyAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(FirstQueenMovePlyRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerFirstQueenMovePlyAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GamesWithQueenMove", "AverageFirstQueenMovePly",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GamesWithQueenMove", "AverageFirstQueenMovePly"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private FirstQueenMovePlyRow EnrichWithBenchmark(
+        FirstQueenMovePlyRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageFirstQueenMovePly,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new FirstQueenMovePlyRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GamesWithQueenMove = row.GamesWithQueenMove,
+            AverageFirstQueenMovePly = row.AverageFirstQueenMovePly,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(FirstQueenMovePlyRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GamesWithQueenMove,
                 r.AverageFirstQueenMovePly
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GamesWithQueenMove", "AverageFirstQueenMovePly"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GamesWithQueenMove,
+            r.AverageFirstQueenMovePly,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(FirstQueenMovePlyRow row)

--- a/src/Services/Analytics/ForwardMoveRateExecutor.cs
+++ b/src/Services/Analytics/ForwardMoveRateExecutor.cs
@@ -6,30 +6,95 @@ namespace Services.Analytics;
 /// <summary>
 /// Mean per-game share of moves landing in the opponent's half (PLAN §12.6 Phase 4).
 /// </summary>
-public sealed class ForwardMoveRateExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class ForwardMoveRateExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "ForwardMoveRate";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetForwardMoveRateAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetForwardMoveRateAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(ForwardMoveRateRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerForwardMoveRateAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "AverageForwardMoveRate",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "AverageForwardMoveRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private ForwardMoveRateRow EnrichWithBenchmark(
+        ForwardMoveRateRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageForwardMoveRate,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new ForwardMoveRateRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            AverageForwardMoveRate = row.AverageForwardMoveRate,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(ForwardMoveRateRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GameCount,
                 r.AverageForwardMoveRate
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GameCount", "AverageForwardMoveRate"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.AverageForwardMoveRate,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(ForwardMoveRateRow row)

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -139,25 +139,49 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<CentreMoveRateRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerCentreMoveRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<ForwardMoveRateRow>> GetForwardMoveRateAsync(
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<ForwardMoveRateRow>>();
+
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerForwardMoveRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
 
     public Task<IReadOnlyList<CastlingSidePreferenceRow>> GetCastlingSidePreferenceAsync(
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<CastlingSidePreferenceRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerCastlingSidePreferenceAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<OppositeSideCastlingRateRow>> GetOppositeSideCastlingRateAsync(
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<OppositeSideCastlingRateRow>>();
+
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerOppositeSideCastlingRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
 
     public Task<IReadOnlyList<UncastledKingRateRow>> GetUncastledKingRateAsync(
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<UncastledKingRateRow>>();
 
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerUncastledKingRateAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<FirstQueenMovePlyRow>> GetFirstQueenMovePlyAsync(
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<FirstQueenMovePlyRow>>();
+
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerFirstQueenMovePlyAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
 
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();

--- a/src/Services/Analytics/OppositeSideCastlingRateExecutor.cs
+++ b/src/Services/Analytics/OppositeSideCastlingRateExecutor.cs
@@ -6,30 +6,95 @@ namespace Services.Analytics;
 /// <summary>
 /// Share of filtered games where both sides castled to opposite wings (PLAN §12.6 Phase 5).
 /// </summary>
-public sealed class OppositeSideCastlingRateExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class OppositeSideCastlingRateExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "OppositeSideCastlingRate";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetOppositeSideCastlingRateAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetOppositeSideCastlingRateAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(OppositeSideCastlingRateRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerOppositeSideCastlingRateAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "EligibleGameCount", "OppositeSideCastlingRate",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "EligibleGameCount", "OppositeSideCastlingRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private OppositeSideCastlingRateRow EnrichWithBenchmark(
+        OppositeSideCastlingRateRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.OppositeSideCastlingRate,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new OppositeSideCastlingRateRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            EligibleGameCount = row.EligibleGameCount,
+            OppositeSideCastlingRate = row.OppositeSideCastlingRate,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(OppositeSideCastlingRateRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.EligibleGameCount,
                 r.OppositeSideCastlingRate
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "EligibleGameCount", "OppositeSideCastlingRate"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.EligibleGameCount,
+            r.OppositeSideCastlingRate,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(OppositeSideCastlingRateRow row)

--- a/src/Services/Analytics/UncastledKingRateExecutor.cs
+++ b/src/Services/Analytics/UncastledKingRateExecutor.cs
@@ -6,30 +6,95 @@ namespace Services.Analytics;
 /// <summary>
 /// Proportion of filtered games where the player never castled (PLAN §12.6 Phase 5).
 /// </summary>
-public sealed class UncastledKingRateExecutor(IChessRepository repository) : IMetricExecutor
+public sealed class UncastledKingRateExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
 {
     private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
 
     public string MetricKey => "UncastledKingRate";
 
     public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
     {
         PlayerStyleMetricValidation.RequirePlayerFilter(query);
-        var rows = await _repository.GetUncastledKingRateAsync(query, cancellationToken).ConfigureAwait(false);
+        var rows = (await _repository.GetUncastledKingRateAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
 
-        IReadOnlyList<object?> Row(UncastledKingRateRow r) =>
-            new object?[]
-            {
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerUncastledKingRateAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "UncastledKingRate",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "UncastledKingRate"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private UncastledKingRateRow EnrichWithBenchmark(
+        UncastledKingRateRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.UncastledKingRate,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new UncastledKingRateRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            UncastledKingRate = row.UncastledKingRate,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(UncastledKingRateRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
                 FormatPlayer(r),
                 r.GameCount,
                 r.UncastledKingRate
-            };
+            ];
+        }
 
-        return new AnalyticsTableResult
-        {
-            ColumnNames = ["Player", "GameCount", "UncastledKingRate"],
-            Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
-        };
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.UncastledKingRate,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
     }
 
     private static string FormatPlayer(UncastledKingRateRow row)

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -60,16 +60,28 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CentreMoveRateRow>());
+        repo.Setup(r => r.GetPerPlayerCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<ForwardMoveRateRow>());
+        repo.Setup(r => r.GetPerPlayerForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<CastlingSidePreferenceRow>());
+        repo.Setup(r => r.GetPerPlayerCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<OppositeSideCastlingRateRow>());
+        repo.Setup(r => r.GetPerPlayerOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<UncastledKingRateRow>());
+        repo.Setup(r => r.GetPerPlayerUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
         repo.Setup(r => r.GetFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<FirstQueenMovePlyRow>());
+        repo.Setup(r => r.GetPerPlayerFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -87,12 +99,12 @@ public class MetricRegistryAndExecutorsTests
             new MinorPieceCompositionExecutor(repo.Object, CorpusBenchmarkCalculator),
             new CaptureRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new QueenTradeRateExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new CentreMoveRateExecutor(repo.Object),
-            new ForwardMoveRateExecutor(repo.Object),
-            new CastlingSidePreferenceExecutor(repo.Object),
-            new OppositeSideCastlingRateExecutor(repo.Object),
-            new UncastledKingRateExecutor(repo.Object),
-            new FirstQueenMovePlyExecutor(repo.Object)
+            new CentreMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new ForwardMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new CastlingSidePreferenceExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new OppositeSideCastlingRateExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -1289,7 +1301,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new CentreMoveRateExecutor(repo.Object);
+        var sut = new CentreMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Kasparov",
@@ -1307,9 +1319,54 @@ public class MetricRegistryAndExecutorsTests
     public async Task CentreMoveRateExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new CentreMoveRateExecutor(repo.Object);
+        var sut = new CentreMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task CentreMoveRateExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CentreMoveRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Kasparov",
+                    PlayerForenames = "Garry",
+                    GameCount = 80,
+                    AverageCentreMoveRate = 0.30
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerCentreMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Kasparov", PlayerForenames = "Garry", GameCount = 80, MetricValue = 0.30 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 0.20 },
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 70, MetricValue = 0.25 }
+            });
+
+        var sut = new CentreMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "AverageCentreMoveRate",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.30, result.Rows[0][2]);
+        Assert.Equal(0.225, result.Rows[0][3]);
+        Assert.Equal(0.075, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
     }
 
     [Fact]
@@ -1326,7 +1383,7 @@ public class MetricRegistryAndExecutorsTests
             MinPlyIndex = 5,
             MaxPlyIndex = 40
         };
-        var sut = new CentreMoveRateExecutor(repo.Object);
+        var sut = new CentreMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 
@@ -1351,7 +1408,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new ForwardMoveRateExecutor(repo.Object);
+        var sut = new ForwardMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Tal",
@@ -1369,9 +1426,54 @@ public class MetricRegistryAndExecutorsTests
     public async Task ForwardMoveRateExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new ForwardMoveRateExecutor(repo.Object);
+        var sut = new ForwardMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task ForwardMoveRateExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ForwardMoveRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Tal",
+                    PlayerForenames = "Mikhail",
+                    GameCount = 80,
+                    AverageForwardMoveRate = 0.50
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerForwardMoveRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 80, MetricValue = 0.50 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 0.35 },
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 70, MetricValue = 0.42 }
+            });
+
+        var sut = new ForwardMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "AverageForwardMoveRate",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.50, result.Rows[0][2]);
+        Assert.Equal(0.385, result.Rows[0][3]);
+        Assert.Equal(0.115, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
     }
 
     [Fact]
@@ -1388,7 +1490,7 @@ public class MetricRegistryAndExecutorsTests
             MinPlyIndex = 8,
             MaxPlyIndex = 35
         };
-        var sut = new ForwardMoveRateExecutor(repo.Object);
+        var sut = new ForwardMoveRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 
@@ -1414,7 +1516,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new CastlingSidePreferenceExecutor(repo.Object);
+        var sut = new CastlingSidePreferenceExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Karpov",
@@ -1433,9 +1535,55 @@ public class MetricRegistryAndExecutorsTests
     public async Task CastlingSidePreferenceExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new CastlingSidePreferenceExecutor(repo.Object);
+        var sut = new CastlingSidePreferenceExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task CastlingSidePreferenceExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CastlingSidePreferenceRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GamesWithCastling = 80,
+                    KingsideRate = 0.80,
+                    QueensideRate = 0.20
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerCastlingSidePreferenceAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Karpov", PlayerForenames = "Anatoly", GameCount = 80, MetricValue = 0.80 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 0.60 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 70, MetricValue = 0.70 }
+            });
+
+        var sut = new CastlingSidePreferenceExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GamesWithCastling", "KingsideRate", "QueensideRate",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.80, result.Rows[0][2]);
+        Assert.Equal(0.65, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(0.15, (double)result.Rows[0][5]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][6]);
+        Assert.Equal(2, result.Rows[0][7]);
     }
 
     [Fact]
@@ -1453,7 +1601,7 @@ public class MetricRegistryAndExecutorsTests
             MaxGameYear = 1970,
             Eco = "A30"
         };
-        var sut = new CastlingSidePreferenceExecutor(repo.Object);
+        var sut = new CastlingSidePreferenceExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 
@@ -1483,7 +1631,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new OppositeSideCastlingRateExecutor(repo.Object);
+        var sut = new OppositeSideCastlingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Tal",
@@ -1501,9 +1649,54 @@ public class MetricRegistryAndExecutorsTests
     public async Task OppositeSideCastlingRateExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new OppositeSideCastlingRateExecutor(repo.Object);
+        var sut = new OppositeSideCastlingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task OppositeSideCastlingRateExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OppositeSideCastlingRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Tal",
+                    PlayerForenames = "Mikhail",
+                    EligibleGameCount = 50,
+                    OppositeSideCastlingRate = 0.50
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerOppositeSideCastlingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 50, MetricValue = 0.50 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 0.25 },
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 70, MetricValue = 0.35 }
+            });
+
+        var sut = new OppositeSideCastlingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Tal",
+            PlayerForenames = "Mikhail",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "EligibleGameCount", "OppositeSideCastlingRate",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.50, result.Rows[0][2]);
+        Assert.Equal(0.30, result.Rows[0][3]);
+        Assert.Equal(0.20, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
     }
 
     [Fact]
@@ -1521,7 +1714,7 @@ public class MetricRegistryAndExecutorsTests
             MinGameYear = 1985,
             MaxGameYear = 1995
         };
-        var sut = new OppositeSideCastlingRateExecutor(repo.Object);
+        var sut = new OppositeSideCastlingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 
@@ -1551,7 +1744,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new UncastledKingRateExecutor(repo.Object);
+        var sut = new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Fischer",
@@ -1569,9 +1762,54 @@ public class MetricRegistryAndExecutorsTests
     public async Task UncastledKingRateExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new UncastledKingRateExecutor(repo.Object);
+        var sut = new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task UncastledKingRateExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<UncastledKingRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Fischer",
+                    PlayerForenames = "Robert James",
+                    GameCount = 100,
+                    UncastledKingRate = 0.10
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerUncastledKingRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Fischer", PlayerForenames = "Robert James", GameCount = 100, MetricValue = 0.10 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 0.05 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 70, MetricValue = 0.08 }
+            });
+
+        var sut = new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Fischer",
+            PlayerForenames = "Robert James",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "UncastledKingRate",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(0.10, result.Rows[0][2]);
+        Assert.Equal(0.065, result.Rows[0][3]);
+        Assert.Equal(0.035, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
     }
 
     [Fact]
@@ -1588,7 +1826,7 @@ public class MetricRegistryAndExecutorsTests
             Eco = "B90",
             MinGameYear = 1960
         };
-        var sut = new UncastledKingRateExecutor(repo.Object);
+        var sut = new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 
@@ -1617,7 +1855,7 @@ public class MetricRegistryAndExecutorsTests
                 }
             });
 
-        var sut = new FirstQueenMovePlyExecutor(repo.Object);
+        var sut = new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator);
         var result = await sut.ExecuteAsync(new AnalyticsQuery
         {
             PlayerSurname = "Kasparov",
@@ -1635,9 +1873,54 @@ public class MetricRegistryAndExecutorsTests
     public async Task FirstQueenMovePlyExecutor_RequiresPlayerSurname()
     {
         var repo = new Mock<IChessRepository>();
-        var sut = new FirstQueenMovePlyExecutor(repo.Object);
+        var sut = new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task FirstQueenMovePlyExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<FirstQueenMovePlyRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Kasparov",
+                    PlayerForenames = "Garry",
+                    GamesWithQueenMove = 45,
+                    AverageFirstQueenMovePly = 8.0
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Kasparov", PlayerForenames = "Garry", GameCount = 45, MetricValue = 8.0 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 12.0 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 70, MetricValue = 6.0 }
+            });
+
+        var sut = new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Kasparov",
+            PlayerForenames = "Garry",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GamesWithQueenMove", "AverageFirstQueenMovePly",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Equal(8.0, result.Rows[0][2]);
+        Assert.Equal(9.0, result.Rows[0][3]);
+        Assert.Equal(-1.0, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(50.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
     }
 
     [Fact]
@@ -1654,7 +1937,7 @@ public class MetricRegistryAndExecutorsTests
             PlayerColour = "Black",
             MaxGameYear = 1975
         };
-        var sut = new FirstQueenMovePlyExecutor(repo.Object);
+        var sut = new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator);
 
         await sut.ExecuteAsync(query);
 


### PR DESCRIPTION
## Summary
- Add corpus benchmark support for six remaining style metrics: CentreMoveRate, ForwardMoveRate, CastlingSidePreference (KingsideRate), OppositeSideCastlingRate, UncastledKingRate, FirstQueenMovePly
- Each metric gains per-player SQL (Appearances CTE), repository methods, executor enrichment via ICorpusBenchmarkCalculator, MetricCatalog hints, and UI catalog entry
- Six new executor tests verify benchmark columns when includeCorpusBenchmark is true

## Test plan
- [x] dotnet test (494 tests pass)
- [ ] CentreMoveRate with includeCorpusBenchmark=true shows CorpusAverage/Delta/Percentile
- [ ] ForwardMoveRate benchmark columns on a known player
- [ ] CastlingSidePreference benchmarks KingsideRate (not QueensideRate)
- [ ] OppositeSideCastlingRate, UncastledKingRate, FirstQueenMovePly benchmark columns in local UI
