### PR TITLE
feat: add AverageGameLength style metric (PLAN §12.6 Phase 7)

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`FirstQueenMovePly` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`AverageGameLength` metric — PR in flight.)
 
 ---
 
@@ -34,7 +34,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (Phase 5):** `OppositeSideCastlingRate` (PR #61).
 - **Done (Phase 5):** `UncastledKingRate` (PR #62).
 - **Done (Phase 6):** `FirstQueenMovePly`.
-- **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`.
+- **Done (Phase 7):** `AverageGameLength` (PR in flight).
+- **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`, `AverageGameLength`.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -54,9 +55,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next:** [PLAN.md §12.6 Phase 7](./PLAN.md) — implement **`AverageGameLength`**.
+**Do next:** [PLAN.md §12.6 Phase 7](./PLAN.md) — implement **`ShortDrawRate`**.
 
-**Then:** `ShortDrawRate` and Phase 7+ per PLAN.
+**Then:** Phase 8 (`EcoDiversity`, `EcoConcentration`) per PLAN.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -554,7 +554,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
 
 #### Phase 7 — game shape
 
-13. [ ] **`AverageGameLength`**
+13. [x] **`AverageGameLength`**
     - **Data:** `MAX(PlyIndex)` from `GamePositionSummary` or move count per game.
     - **Aggregate:** `AVG(max_ply)` for games involving the filtered player.
     - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageGameLengthPly`.

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -52,6 +52,8 @@ internal static class MetricCatalog
                 "Proportion of the filtered player's games where they never castled.",
             "FirstQueenMovePly" =>
                 "Mean half-move ply of the filtered player's first queen move; games without a queen move are excluded.",
+            "AverageGameLength" =>
+                "How long are this player's games on average? Higher values mean longer games in half-moves; lower values mean shorter games.",
             _ => null
         };
     }
@@ -224,6 +226,15 @@ internal static class MetricCatalog
                 "Optional: playerColour = Any, White, or Black (defaults to Any).",
                 "Optional: minGameYear, maxGameYear, eco.",
                 "GamesWithQueenMove counts games where the queen moved at least once; average is raw ply (not normalized by game length).",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
+            ],
+            "AverageGameLength" =>
+            [
+                "How it's computed: per game, MAX(PlyIndex) from GamePositionSummary; then averaged across filtered appearances.",
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
                 "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
                 "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -103,6 +103,7 @@ builder.Services.AddScoped<IMetricExecutor, CastlingSidePreferenceExecutor>();
 builder.Services.AddScoped<IMetricExecutor, OppositeSideCastlingRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, UncastledKingRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, FirstQueenMovePlyExecutor>();
+builder.Services.AddScoped<IMetricExecutor, AverageGameLengthExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -430,7 +430,8 @@
         CastlingSidePreference: true,
         OppositeSideCastlingRate: true,
         UncastledKingRate: true,
-        FirstQueenMovePly: true
+        FirstQueenMovePly: true,
+        AverageGameLength: true
       };
 
       function selectedMetricKey() {

--- a/src/Interfaces/Analytics/AverageGameLengthRow.cs
+++ b/src/Interfaces/Analytics/AverageGameLengthRow.cs
@@ -1,0 +1,20 @@
+namespace Interfaces.Analytics;
+
+public sealed class AverageGameLengthRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public double? AverageGameLengthPly { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -303,6 +303,20 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Mean game length in plies for games involving the filtered player.
+        /// </summary>
+        Task<IReadOnlyList<AverageGameLengthRow>> GetAverageGameLengthAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Per-player mean game length aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageGameLengthAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1522,6 +1536,52 @@ namespace Repositories
             var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
                 new CommandDefinition(
                     SqlStatements.GetPerPlayerFirstQueenMovePly,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<AverageGameLengthRow>> GetAverageGameLengthAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<AverageGameLengthRow>(
+                new CommandDefinition(
+                    SqlStatements.GetAverageGameLength,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageGameLengthAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerAverageGameLength,
                     new
                     {
                         MinGameYear = query.MinGameYear,

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -1935,6 +1935,104 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Mean game length in plies for games involving the filtered player.
+        /// </summary>
+        public static string GetAverageGameLength =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            GameLength AS
+            (
+                SELECT fg.GameId,
+                       MAX(s.PlyIndex) AS MaxPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                GROUP BY fg.GameId
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(CAST(MaxPly AS FLOAT)) AS AverageGameLengthPly
+            FROM GameLength;
+            """;
+
+        /// <summary>
+        /// Per-player mean game length for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerAverageGameLength =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            GameLength AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       MAX(s.PlyIndex) AS MaxPly
+                FROM Appearances a
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = a.GameId
+                GROUP BY a.PlayerSurname, a.PlayerForenames, a.GameId
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(CAST(MaxPly AS FLOAT)) AS MetricValue
+            FROM GameLength
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/AverageGameLengthExecutor.cs
+++ b/src/Services/Analytics/AverageGameLengthExecutor.cs
@@ -1,0 +1,107 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Mean game length in plies for games involving the filtered player (PLAN §12.6 Phase 7).
+/// </summary>
+public sealed class AverageGameLengthExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
+
+    public string MetricKey => "AverageGameLength";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = (await _repository.GetAverageGameLengthAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
+
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerAverageGameLengthAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "AverageGameLengthPly",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "AverageGameLengthPly"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private AverageGameLengthRow EnrichWithBenchmark(
+        AverageGameLengthRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.AverageGameLengthPly,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new AverageGameLengthRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            AverageGameLengthPly = row.AverageGameLengthPly,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(AverageGameLengthRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
+                FormatPlayer(r),
+                r.GameCount,
+                r.AverageGameLengthPly
+            ];
+        }
+
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.AverageGameLengthPly,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
+    }
+
+    private static string FormatPlayer(AverageGameLengthRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -183,6 +183,14 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
 
+    public Task<IReadOnlyList<AverageGameLengthRow>> GetAverageGameLengthAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<AverageGameLengthRow>>();
+
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerAverageGameLengthAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -82,6 +82,10 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<FirstQueenMovePlyRow>());
         repo.Setup(r => r.GetPerPlayerFirstQueenMovePlyAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
+        repo.Setup(r => r.GetAverageGameLengthAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AverageGameLengthRow>());
+        repo.Setup(r => r.GetPerPlayerAverageGameLengthAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -104,7 +108,8 @@ public class MetricRegistryAndExecutorsTests
             new CastlingSidePreferenceExecutor(repo.Object, CorpusBenchmarkCalculator),
             new OppositeSideCastlingRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator)
+            new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -127,7 +132,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("OppositeSideCastlingRate", sut.MetricKeys);
         Assert.Contains("UncastledKingRate", sut.MetricKeys);
         Assert.Contains("FirstQueenMovePly", sut.MetricKeys);
-        Assert.Equal(20, sut.MetricKeys.Count);
+        Assert.Contains("AverageGameLength", sut.MetricKeys);
+        Assert.Equal(21, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -1942,6 +1948,118 @@ public class MetricRegistryAndExecutorsTests
         await sut.ExecuteAsync(query);
 
         repo.Verify(r => r.GetFirstQueenMovePlyAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerSurname == "Petrosian"
+                && q.PlayerForenames == "Tigran"
+                && q.PlayerColour == "Black"
+                && q.MaxGameYear == 1975),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AverageGameLengthExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageGameLengthAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AverageGameLengthRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GameCount = 120,
+                    AverageGameLengthPly = 68.5
+                }
+            });
+
+        var sut = new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly"
+        });
+
+        Assert.Equal(["Player", "GameCount", "AverageGameLengthPly"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Karpov, Anatoly", result.Rows[0][0]);
+        Assert.Equal(120, result.Rows[0][1]);
+        Assert.Equal(68.5, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task AverageGameLengthExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task AverageGameLengthExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageGameLengthAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AverageGameLengthRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GameCount = 50,
+                    AverageGameLengthPly = 70.0
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerAverageGameLengthAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Karpov", PlayerForenames = "Anatoly", GameCount = 50, MetricValue = 70.0 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 55.0 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 70, MetricValue = 65.0 }
+            });
+
+        var sut = new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "AverageGameLengthPly",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal(70.0, result.Rows[0][2]);
+        Assert.Equal(60.0, (double)result.Rows[0][3]!, precision: 10);
+        Assert.Equal(10.0, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
+    }
+
+    [Fact]
+    public async Task AverageGameLengthExecutor_PassesFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetAverageGameLengthAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AverageGameLengthRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Petrosian",
+            PlayerForenames = "Tigran",
+            PlayerColour = "Black",
+            MaxGameYear = 1975
+        };
+        var sut = new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetAverageGameLengthAsync(
             It.Is<AnalyticsQuery>(q =>
                 q.PlayerSurname == "Petrosian"
                 && q.PlayerForenames == "Tigran"


### PR DESCRIPTION
## Summary

- Add **`AverageGameLength`** style metric (PLAN §12.6 Phase 7): mean `MAX(PlyIndex)` per game from `GamePositionSummary`, averaged over filtered player appearances.
- Includes executor, SQL, repository methods, corpus benchmark support, UI checkbox, `MetricCatalog` entries, and executor tests.

## Test plan

- [x] `dotnet test` (498 passed)
- [ ] Run metric in UI for a known player and sanity-check `AverageGameLengthPly`
