### PR TITLE
feat: add ShortDrawRate style metric (PLAN §12.6 Phase 7)

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`AverageGameLength` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`ShortDrawRate` metric — PR in flight.)
 
 ---
 
@@ -34,8 +34,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (Phase 5):** `OppositeSideCastlingRate` (PR #61).
 - **Done (Phase 5):** `UncastledKingRate` (PR #62).
 - **Done (Phase 6):** `FirstQueenMovePly`.
-- **Done (Phase 7):** `AverageGameLength` (PR in flight).
-- **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`, `AverageGameLength`.
+- **Done (Phase 7):** `AverageGameLength`, `ShortDrawRate` (PR in flight).
+- **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`, `AverageGameLength`, `ShortDrawRate`.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -55,9 +55,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next:** [PLAN.md §12.6 Phase 7](./PLAN.md) — implement **`ShortDrawRate`**.
+**Do next:** [PLAN.md §12.6 Phase 8](./PLAN.md) — implement **`EcoDiversity`**.
 
-**Then:** Phase 8 (`EcoDiversity`, `EcoConcentration`) per PLAN.
+**Then:** `EcoConcentration` and Phase 8+ per PLAN.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -559,7 +559,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
     - **Aggregate:** `AVG(max_ply)` for games involving the filtered player.
     - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `AverageGameLengthPly`.
 
-14. [ ] **`ShortDrawRate`**
+14. [x] **`ShortDrawRate`**
     - **Data:** `Game.Winner` draw detection + game length.
     - **Per game:** among draws only, `1` if `max_ply <= shortDrawMaxPly` (default **20**), else `0`.
     - **Aggregate:** proportion of draws that are short (ChessBase **Fighting Spirit** proxy).

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -54,6 +54,8 @@ internal static class MetricCatalog
                 "How early does this player move their queen? Lower values mean an earlier first queen move. Games where the queen never moved are excluded.",
             "AverageGameLength" =>
                 "How long are this player's games on average? Higher values mean longer games in half-moves; lower values mean shorter games.",
+            "ShortDrawRate" =>
+                "How often are this player's draws short? Higher values mean more of their drawn games end at or below the ply threshold (ChessBase fighting-spirit proxy).",
             _ => null
         };
     }
@@ -248,6 +250,17 @@ internal static class MetricCatalog
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
                 "Optional: benchmarkMinGames (default 30) for corpus eligibility."
+            ],
+            "ShortDrawRate" =>
+            [
+                "How it's computed: among draws only (Winner = D), 1 if MAX(PlyIndex) <= shortDrawMaxPly, else 0; then averaged.",
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "Optional: shortDrawMaxPly (defaults to 20 when omitted).",
+                "DrawCount is the number of filtered draws; non-draws are excluded.",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility (applied to draw count)."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -104,6 +104,7 @@ builder.Services.AddScoped<IMetricExecutor, OppositeSideCastlingRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, UncastledKingRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, FirstQueenMovePlyExecutor>();
 builder.Services.AddScoped<IMetricExecutor, AverageGameLengthExecutor>();
+builder.Services.AddScoped<IMetricExecutor, ShortDrawRateExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -431,7 +431,8 @@
         OppositeSideCastlingRate: true,
         UncastledKingRate: true,
         FirstQueenMovePly: true,
-        AverageGameLength: true
+        AverageGameLength: true,
+        ShortDrawRate: true
       };
 
       function selectedMetricKey() {

--- a/src/Interfaces/Analytics/AnalyticsQuery.cs
+++ b/src/Interfaces/Analytics/AnalyticsQuery.cs
@@ -58,6 +58,11 @@ public sealed class AnalyticsQuery
     public int? QueenTradeMaxPly { get; init; }
 
     /// <summary>
+    /// For <c>ShortDrawRate</c> — draws at or below this ply count as short (default 20).
+    /// </summary>
+    public int? ShortDrawMaxPly { get; init; }
+
+    /// <summary>
     /// When true, eligible style metrics append corpus benchmark columns (DESIGN §12).
     /// </summary>
     public bool? IncludeCorpusBenchmark { get; init; }

--- a/src/Interfaces/Analytics/ShortDrawRateRow.cs
+++ b/src/Interfaces/Analytics/ShortDrawRateRow.cs
@@ -1,0 +1,22 @@
+namespace Interfaces.Analytics;
+
+public sealed class ShortDrawRateRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int DrawCount { get; init; }
+
+    public double? ShortDrawRate { get; init; }
+
+    public int ShortDrawMaxPly { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -317,6 +317,22 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Share of the filtered player's draws that end at or below a ply threshold.
+        /// </summary>
+        Task<IReadOnlyList<ShortDrawRateRow>> GetShortDrawRateAsync(
+            AnalyticsQuery query,
+            int shortDrawMaxPly,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Per-player short-draw rate aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerShortDrawRateAsync(
+            AnalyticsQuery query,
+            int shortDrawMaxPly,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1588,6 +1604,56 @@ namespace Repositories
                         MaxGameYear = query.MaxGameYear,
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<ShortDrawRateRow>> GetShortDrawRateAsync(
+            AnalyticsQuery query,
+            int shortDrawMaxPly,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<ShortDrawRateRow>(
+                new CommandDefinition(
+                    SqlStatements.GetShortDrawRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        ShortDrawMaxPly = shortDrawMaxPly
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerShortDrawRateAsync(
+            AnalyticsQuery query,
+            int shortDrawMaxPly,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerShortDrawRate,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco),
+                        ShortDrawMaxPly = shortDrawMaxPly
                     },
                     cancellationToken: cancellationToken))).ToList();
 

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -2033,6 +2033,121 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Share of the filtered player's draws that end at or below a ply threshold.
+        /// </summary>
+        public static string GetShortDrawRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       g.Winner,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            DrawGames AS
+            (
+                SELECT fg.GameId,
+                       MAX(s.PlyIndex) AS MaxPly
+                FROM FilteredGames fg
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = fg.GameId
+                WHERE fg.PlayerSide IS NOT NULL
+                  AND fg.Winner = 'D'
+                GROUP BY fg.GameId
+            ),
+            PerDraw AS
+            (
+                SELECT CASE
+                           WHEN MaxPly <= @ShortDrawMaxPly THEN 1.0
+                           ELSE 0.0
+                       END AS IsShortDraw
+                FROM DrawGames
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS DrawCount,
+                   AVG(IsShortDraw) AS ShortDrawRate,
+                   @ShortDrawMaxPly AS ShortDrawMaxPly
+            FROM PerDraw;
+            """;
+
+        /// <summary>
+        /// Per-player short-draw rate for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerShortDrawRate =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       g.Winner,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            ),
+            DrawGames AS
+            (
+                SELECT a.PlayerSurname,
+                       a.PlayerForenames,
+                       a.GameId,
+                       MAX(s.PlyIndex) AS MaxPly
+                FROM Appearances a
+                INNER JOIN dbo.Game g ON g.Id = a.GameId
+                INNER JOIN dbo.GamePositionSummary s ON s.GameId = a.GameId
+                WHERE g.Winner = 'D'
+                GROUP BY a.PlayerSurname, a.PlayerForenames, a.GameId
+            )
+            SELECT PlayerSurname,
+                   PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   AVG(CASE
+                           WHEN MaxPly <= @ShortDrawMaxPly THEN 1.0
+                           ELSE 0.0
+                       END) AS MetricValue
+            FROM DrawGames
+            GROUP BY PlayerSurname, PlayerForenames
+            ORDER BY MetricValue DESC, PlayerSurname, PlayerForenames;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -191,6 +191,16 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         AnalyticsQuery query,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
 
+    public Task<IReadOnlyList<ShortDrawRateRow>> GetShortDrawRateAsync(
+        AnalyticsQuery query,
+        int shortDrawMaxPly,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<ShortDrawRateRow>>();
+
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerShortDrawRateAsync(
+        AnalyticsQuery query,
+        int shortDrawMaxPly,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/src/Services/Analytics/ShortDrawMaxPlyDefaults.cs
+++ b/src/Services/Analytics/ShortDrawMaxPlyDefaults.cs
@@ -1,0 +1,14 @@
+using Interfaces.Analytics;
+
+namespace Services.Analytics;
+
+internal static class ShortDrawMaxPlyDefaults
+{
+    public const int DefaultShortDrawMaxPly = 20;
+
+    public static int Resolve(AnalyticsQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return query.ShortDrawMaxPly ?? DefaultShortDrawMaxPly;
+    }
+}

--- a/src/Services/Analytics/ShortDrawRateExecutor.cs
+++ b/src/Services/Analytics/ShortDrawRateExecutor.cs
@@ -1,0 +1,111 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Share of the filtered player's draws that end at or below a ply threshold (PLAN §12.6 Phase 7).
+/// </summary>
+public sealed class ShortDrawRateExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
+
+    public string MetricKey => "ShortDrawRate";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var shortDrawMaxPly = ShortDrawMaxPlyDefaults.Resolve(query);
+        var rows = (await _repository.GetShortDrawRateAsync(query, shortDrawMaxPly, cancellationToken).ConfigureAwait(false)).ToList();
+
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerShortDrawRateAsync(query, shortDrawMaxPly, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "DrawCount", "ShortDrawRate", "ShortDrawMaxPly",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "DrawCount", "ShortDrawRate", "ShortDrawMaxPly"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private ShortDrawRateRow EnrichWithBenchmark(
+        ShortDrawRateRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.ShortDrawRate,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new ShortDrawRateRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            DrawCount = row.DrawCount,
+            ShortDrawRate = row.ShortDrawRate,
+            ShortDrawMaxPly = row.ShortDrawMaxPly,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(ShortDrawRateRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
+                FormatPlayer(r),
+                r.DrawCount,
+                r.ShortDrawRate,
+                r.ShortDrawMaxPly
+            ];
+        }
+
+        return
+        [
+            FormatPlayer(r),
+            r.DrawCount,
+            r.ShortDrawRate,
+            r.ShortDrawMaxPly,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
+    }
+
+    private static string FormatPlayer(ShortDrawRateRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -86,6 +86,10 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<AverageGameLengthRow>());
         repo.Setup(r => r.GetPerPlayerAverageGameLengthAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
+        repo.Setup(r => r.GetShortDrawRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ShortDrawRateRow>());
+        repo.Setup(r => r.GetPerPlayerShortDrawRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -109,7 +113,8 @@ public class MetricRegistryAndExecutorsTests
             new OppositeSideCastlingRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator)
+            new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new ShortDrawRateExecutor(repo.Object, CorpusBenchmarkCalculator)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -133,7 +138,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("UncastledKingRate", sut.MetricKeys);
         Assert.Contains("FirstQueenMovePly", sut.MetricKeys);
         Assert.Contains("AverageGameLength", sut.MetricKeys);
-        Assert.Equal(21, sut.MetricKeys.Count);
+        Assert.Contains("ShortDrawRate", sut.MetricKeys);
+        Assert.Equal(22, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -2065,6 +2071,127 @@ public class MetricRegistryAndExecutorsTests
                 && q.PlayerForenames == "Tigran"
                 && q.PlayerColour == "Black"
                 && q.MaxGameYear == 1975),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ShortDrawRateExecutor_MapsRowAndUsesDefaultMaxPly()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetShortDrawRateAsync(
+                It.IsAny<AnalyticsQuery>(),
+                20,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ShortDrawRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Petrosian",
+                    PlayerForenames = "Tigran",
+                    DrawCount = 30,
+                    ShortDrawRate = 0.2,
+                    ShortDrawMaxPly = 20
+                }
+            });
+
+        var sut = new ShortDrawRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Petrosian",
+            PlayerForenames = "Tigran"
+        });
+
+        Assert.Equal(["Player", "DrawCount", "ShortDrawRate", "ShortDrawMaxPly"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Petrosian, Tigran", result.Rows[0][0]);
+        Assert.Equal(30, result.Rows[0][1]);
+        Assert.Equal(0.2, result.Rows[0][2]);
+        Assert.Equal(20, result.Rows[0][3]);
+    }
+
+    [Fact]
+    public async Task ShortDrawRateExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new ShortDrawRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task ShortDrawRateExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetShortDrawRateAsync(
+                It.IsAny<AnalyticsQuery>(),
+                20,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ShortDrawRateRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    DrawCount = 40,
+                    ShortDrawRate = 0.25,
+                    ShortDrawMaxPly = 20
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerShortDrawRateAsync(
+                It.IsAny<AnalyticsQuery>(),
+                20,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Karpov", PlayerForenames = "Anatoly", GameCount = 40, MetricValue = 0.25 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 50, MetricValue = 0.10 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 35, MetricValue = 0.15 }
+            });
+
+        var sut = new ShortDrawRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "DrawCount", "ShortDrawRate", "ShortDrawMaxPly",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal(0.25, result.Rows[0][2]);
+        Assert.Equal(20, result.Rows[0][3]);
+        Assert.Equal(0.125, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(0.125, (double)result.Rows[0][5]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][6]);
+        Assert.Equal(2, result.Rows[0][7]);
+    }
+
+    [Fact]
+    public async Task ShortDrawRateExecutor_PassesCustomMaxPlyToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetShortDrawRateAsync(
+                It.IsAny<AnalyticsQuery>(),
+                15,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ShortDrawRateRow>());
+
+        var sut = new ShortDrawRateExecutor(repo.Object, CorpusBenchmarkCalculator);
+        await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Fischer",
+            ShortDrawMaxPly = 15
+        });
+
+        repo.Verify(r => r.GetShortDrawRateAsync(
+            It.Is<AnalyticsQuery>(q => q.PlayerSurname == "Fischer" && q.ShortDrawMaxPly == 15),
+            15,
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary

- Add **`ShortDrawRate`** style metric (PLAN §12.6 Phase 7): among draws only (`Winner = D`), proportion where `MAX(PlyIndex) <= shortDrawMaxPly` (default **20**).
- Includes `ShortDrawMaxPly` on `AnalyticsQuery`, executor, SQL, repository methods, corpus benchmark support, UI checkbox, `MetricCatalog` entries, and tests.

## Test plan

- [x] `dotnet test` (502 passed)
- [ ] Run metric for a draw-heavy player; verify `DrawCount` and `ShortDrawRate`
