### PR TITLE
feat: add ScorePercentage to PlayerResultSummary

### DIFF
--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -25,7 +25,7 @@ internal static class MetricCatalog
             "GameCountByPlayer" =>
                 "Count of player appearances, split by White and Black games, with optional year, player-name, and ECO filters.",
             "PlayerResultSummary" =>
-                "Player result summary from each player's perspective: wins, losses, draws, unknown results, total games, and score.",
+                "Player result summary from each player's perspective: wins, losses, draws, unknown results, total games, score, and score percentage.",
             "AverageMaterialByPlayerAtMove" =>
                 "Average material at a full move for Player A compared with Player B, or all players, with colour mode Any/White/Black.",
             "AverageCastlingPly" =>
@@ -110,7 +110,8 @@ internal static class MetricCatalog
                 "Optional: minGameYear, maxGameYear, eco.",
                 "Optional player filter narrows the game set before summarizing player results.",
                 "playerColour = Any, White, or Black is independent from player identity.",
-                "Wins and losses are calculated from each player's perspective; draws score 0.5."
+                "Wins and losses are calculated from each player's perspective; draws score 0.5 in Score.",
+                "ScorePercentage = (wins + 0.5 × draws) ÷ (wins + losses + draws) × 100; unknown results are excluded from the denominator."
             ],
             "AverageMaterialByPlayerAtMove" =>
             [

--- a/src/Interfaces/Analytics/PlayerResultSummaryRow.cs
+++ b/src/Interfaces/Analytics/PlayerResultSummaryRow.cs
@@ -17,4 +17,9 @@ public sealed class PlayerResultSummaryRow
     public int TotalGameCount { get; init; }
 
     public double Score { get; init; }
+
+    /// <summary>
+    /// Normalised performance: (wins + 0.5 × draws) ÷ (wins + losses + draws) × 100. Null when there are no decisive-or-draw games.
+    /// </summary>
+    public double? ScorePercentage { get; init; }
 }

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -322,7 +322,13 @@ namespace Repositories
                    SUM(a.DrawCount) AS DrawCount,
                    SUM(a.UnknownCount) AS UnknownCount,
                    COUNT(*) AS TotalGameCount,
-                   CAST(SUM(a.WinCount) AS FLOAT) + (CAST(SUM(a.DrawCount) AS FLOAT) / 2.0) AS Score
+                   CAST(SUM(a.WinCount) AS FLOAT) + (CAST(SUM(a.DrawCount) AS FLOAT) / 2.0) AS Score,
+                   CASE
+                       WHEN SUM(a.WinCount) + SUM(a.LossCount) + SUM(a.DrawCount) = 0 THEN NULL
+                       ELSE (CAST(SUM(a.WinCount) AS FLOAT) + (CAST(SUM(a.DrawCount) AS FLOAT) / 2.0))
+                            / CAST(SUM(a.WinCount) + SUM(a.LossCount) + SUM(a.DrawCount) AS FLOAT)
+                            * 100.0
+                   END AS ScorePercentage
             FROM Appearance a
             INNER JOIN dbo.Player p ON p.Id = a.PlayerId
             GROUP BY p.Surname, p.Forenames

--- a/src/Services/Analytics/PlayerResultSummaryExecutor.cs
+++ b/src/Services/Analytics/PlayerResultSummaryExecutor.cs
@@ -26,12 +26,13 @@ public sealed class PlayerResultSummaryExecutor(IChessRepository repository) : I
                 r.DrawCount,
                 r.UnknownCount,
                 r.TotalGameCount,
-                r.Score
+                r.Score,
+                r.ScorePercentage
             };
 
         return new AnalyticsTableResult
         {
-            ColumnNames = ["Player", "WinCount", "LossCount", "DrawCount", "UnknownCount", "TotalGameCount", "Score"],
+            ColumnNames = ["Player", "WinCount", "LossCount", "DrawCount", "UnknownCount", "TotalGameCount", "Score", "ScorePercentage"],
             Rows = rows.Select(r => (IReadOnlyList<object?>)Row(r).ToList()).ToList()
         };
     }

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -456,15 +456,16 @@ public class MetricRegistryAndExecutorsTests
         repo.Setup(r => r.GetPlayerResultSummariesAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<PlayerResultSummaryRow>
             {
-                new() { PlayerSurname = "Kasparov", PlayerForenames = "Garry", WinCount = 12, LossCount = 3, DrawCount = 10, UnknownCount = 1, TotalGameCount = 26, Score = 17 },
-                new() { PlayerSurname = "Tal", PlayerForenames = "", WinCount = 5, LossCount = 2, DrawCount = 4, UnknownCount = 0, TotalGameCount = 11, Score = 7 }
+                new() { PlayerSurname = "Kasparov", PlayerForenames = "Garry", WinCount = 12, LossCount = 3, DrawCount = 10, UnknownCount = 1, TotalGameCount = 26, Score = 17, ScorePercentage = 68.0 },
+                new() { PlayerSurname = "Example", PlayerForenames = "", WinCount = 10, LossCount = 4, DrawCount = 6, UnknownCount = 0, TotalGameCount = 20, Score = 13, ScorePercentage = 65.0 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "", WinCount = 5, LossCount = 2, DrawCount = 4, UnknownCount = 0, TotalGameCount = 11, Score = 7, ScorePercentage = 63.63636363636363 }
             });
 
         var sut = new PlayerResultSummaryExecutor(repo.Object);
         var result = await sut.ExecuteAsync(new AnalyticsQuery());
 
-        Assert.Equal(["Player", "WinCount", "LossCount", "DrawCount", "UnknownCount", "TotalGameCount", "Score"], result.ColumnNames);
-        Assert.Equal(2, result.Rows.Count);
+        Assert.Equal(["Player", "WinCount", "LossCount", "DrawCount", "UnknownCount", "TotalGameCount", "Score", "ScorePercentage"], result.ColumnNames);
+        Assert.Equal(3, result.Rows.Count);
         Assert.Equal("Kasparov, Garry", result.Rows[0][0]);
         Assert.Equal(12, result.Rows[0][1]);
         Assert.Equal(3, result.Rows[0][2]);
@@ -472,7 +473,10 @@ public class MetricRegistryAndExecutorsTests
         Assert.Equal(1, result.Rows[0][4]);
         Assert.Equal(26, result.Rows[0][5]);
         Assert.Equal(17d, result.Rows[0][6]);
-        Assert.Equal("Tal", result.Rows[1][0]);
+        Assert.Equal(68.0, result.Rows[0][7]);
+        Assert.Equal("Example", result.Rows[1][0]);
+        Assert.Equal(65.0, result.Rows[1][7]);
+        Assert.Equal("Tal", result.Rows[2][0]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add **`ScorePercentage`** column to `PlayerResultSummary`: `(wins + 0.5 × draws) ÷ (wins + losses + draws) × 100`.
- Unknown results are excluded from the denominator; null when there are no W/L/D games.
- Existing **`Score`** column (raw points) is unchanged.

## Test plan

- [x] `dotnet test` — PlayerResultSummary executor tests pass (includes 10W/4L/6D → 65% example)
- [ ] Run `PlayerResultSummary` in UI and verify new column appears after `Score`
