### PR TITLE
feat: add EcoDiversity style metric (PLAN §12.6 Phase 8)

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`ShortDrawRate` metric — PR in flight.)
+**Last updated:** 2026-06-11 (`EcoDiversity` metric — PR in flight.)
 
 ---
 
@@ -34,8 +34,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (Phase 5):** `OppositeSideCastlingRate` (PR #61).
 - **Done (Phase 5):** `UncastledKingRate` (PR #62).
 - **Done (Phase 6):** `FirstQueenMovePly`.
-- **Done (Phase 7):** `AverageGameLength`, `ShortDrawRate` (PR in flight).
-- **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`, `AverageGameLength`, `ShortDrawRate`.
+- **Done (Phase 7):** `AverageGameLength`, `ShortDrawRate`.
+- **Done (Phase 8):** `EcoDiversity` (PR in flight).
+- **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`, `AverageGameLength`, `ShortDrawRate`, `EcoDiversity`.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 
 ---
@@ -55,9 +56,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next:** [PLAN.md §12.6 Phase 8](./PLAN.md) — implement **`EcoDiversity`**.
+**Do next:** [PLAN.md §12.6 Phase 8](./PLAN.md) — implement **`EcoConcentration`**.
 
-**Then:** `EcoConcentration` and Phase 8+ per PLAN.
+**Then:** Phase 9+ per PLAN.
 
 **Do not prioritize yet:** HTTP auth / rate limits for metrics (PLAN §12.4 / §13).
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -569,7 +569,7 @@ Document defaults in `MetricCatalog.GetParameterHints` when added.
 
 #### Phase 8 — repertoire shape
 
-15. [ ] **`EcoDiversity`**
+15. [x] **`EcoDiversity`**
     - **Data:** `Game.Eco` for games involving the player.
     - **Aggregate:** `COUNT(DISTINCT Eco)` (exclude null ECO).
     - **Result columns:** `PlayerSurname`, `PlayerForenames`, `GameCount`, `EcoDiversity`.

--- a/src/Analyser/Models/MetricCatalog.cs
+++ b/src/Analyser/Models/MetricCatalog.cs
@@ -56,6 +56,8 @@ internal static class MetricCatalog
                 "How long are this player's games on average? Higher values mean longer games in half-moves; lower values mean shorter games.",
             "ShortDrawRate" =>
                 "How often are this player's draws short? Higher values mean more of their drawn games end at or below the ply threshold (ChessBase fighting-spirit proxy).",
+            "EcoDiversity" =>
+                "How varied is this player's opening repertoire? Higher values mean they have played more distinct ECO codes.",
             _ => null
         };
     }
@@ -261,6 +263,16 @@ internal static class MetricCatalog
                 "DrawCount is the number of filtered draws; non-draws are excluded.",
                 "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
                 "Optional: benchmarkMinGames (default 30) for corpus eligibility (applied to draw count)."
+            ],
+            "EcoDiversity" =>
+            [
+                "How it's computed: COUNT(DISTINCT Eco) over filtered appearances; null or blank ECO values are excluded from the count.",
+                "Required: playerSurname (playerForenames optional but recommended).",
+                "Optional: playerColour = Any, White, or Black (defaults to Any).",
+                "Optional: minGameYear, maxGameYear, eco.",
+                "GameCount is all filtered appearances (including games without ECO).",
+                "Optional: includeCorpusBenchmark = true adds CorpusAverage, DeltaFromCorpus, CorpusPercentile, CorpusEligiblePlayerCount.",
+                "Optional: benchmarkMinGames (default 30) for corpus eligibility."
             ],
             _ => []
         };

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -105,6 +105,7 @@ builder.Services.AddScoped<IMetricExecutor, UncastledKingRateExecutor>();
 builder.Services.AddScoped<IMetricExecutor, FirstQueenMovePlyExecutor>();
 builder.Services.AddScoped<IMetricExecutor, AverageGameLengthExecutor>();
 builder.Services.AddScoped<IMetricExecutor, ShortDrawRateExecutor>();
+builder.Services.AddScoped<IMetricExecutor, EcoDiversityExecutor>();
 builder.Services.AddScoped<IMetricRegistry, MetricRegistry>();
 builder.Services.AddScoped<IAnalyticsBackfillService, AnalyticsBackfillService>();
 

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -432,7 +432,8 @@
         UncastledKingRate: true,
         FirstQueenMovePly: true,
         AverageGameLength: true,
-        ShortDrawRate: true
+        ShortDrawRate: true,
+        EcoDiversity: true
       };
 
       function selectedMetricKey() {

--- a/src/Interfaces/Analytics/EcoDiversityRow.cs
+++ b/src/Interfaces/Analytics/EcoDiversityRow.cs
@@ -1,0 +1,20 @@
+namespace Interfaces.Analytics;
+
+public sealed class EcoDiversityRow
+{
+    public string PlayerSurname { get; init; } = string.Empty;
+
+    public string? PlayerForenames { get; init; }
+
+    public int GameCount { get; init; }
+
+    public int EcoDiversity { get; init; }
+
+    public double? CorpusAverage { get; init; }
+
+    public double? DeltaFromCorpus { get; init; }
+
+    public double? CorpusPercentile { get; init; }
+
+    public int? CorpusEligiblePlayerCount { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -333,6 +333,20 @@ namespace Repositories
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Count of distinct ECO codes in games involving the filtered player.
+        /// </summary>
+        Task<IReadOnlyList<EcoDiversityRow>> GetEcoDiversityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Per-player distinct ECO count aggregates for corpus benchmarks.
+        /// </summary>
+        Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerEcoDiversityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Game primary keys that have board rows but no <c>GameMove</c> rows (candidates for analytics backfill).
         /// </summary>
         Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default);
@@ -1654,6 +1668,52 @@ namespace Repositories
                         PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
                         Eco = NormalizeNonEmpty(query.Eco),
                         ShortDrawMaxPly = shortDrawMaxPly
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<EcoDiversityRow>> GetEcoDiversityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<EcoDiversityRow>(
+                new CommandDefinition(
+                    SqlStatements.GetEcoDiversity,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerSurname = NormalizeNonEmpty(query.PlayerSurname),
+                        PlayerForenames = NormalizeNamePart(query.PlayerForenames),
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
+                    },
+                    cancellationToken: cancellationToken))).ToList();
+
+            return rows;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerEcoDiversityAsync(
+            AnalyticsQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            using var connection = GetOpenConnection();
+            var rows = (await connection.QueryAsync<PlayerStylePerPlayerMetricRow>(
+                new CommandDefinition(
+                    SqlStatements.GetPerPlayerEcoDiversity,
+                    new
+                    {
+                        MinGameYear = query.MinGameYear,
+                        MaxGameYear = query.MaxGameYear,
+                        PlayerColour = NormalizePlayerColourFilter(query.PlayerColour),
+                        Eco = NormalizeNonEmpty(query.Eco)
                     },
                     cancellationToken: cancellationToken))).ToList();
 

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -2148,6 +2148,98 @@ namespace Repositories
             """;
 
         /// <summary>
+        /// Count of distinct ECO codes in games involving the filtered player.
+        /// </summary>
+        public static string GetEcoDiversity =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       g.Eco,
+                       CASE
+                           WHEN wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames) THEN CAST('W' AS CHAR(1))
+                           WHEN bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames) THEN CAST('B' AS CHAR(1))
+                           ELSE NULL
+                       END AS PlayerSide
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+                  AND (
+                      (@PlayerColour = 'Any' AND (
+                          (wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                          OR (bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                      ))
+                      OR (@PlayerColour = 'White' AND wp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR wp.Forenames = @PlayerForenames))
+                      OR (@PlayerColour = 'Black' AND bp.Surname = @PlayerSurname AND (@PlayerForenames IS NULL OR bp.Forenames = @PlayerForenames))
+                  )
+            ),
+            PlayerGames AS
+            (
+                SELECT fg.Eco
+                FROM FilteredGames fg
+                WHERE fg.PlayerSide IS NOT NULL
+            )
+            SELECT @PlayerSurname AS PlayerSurname,
+                   @PlayerForenames AS PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   COUNT(DISTINCT CASE
+                       WHEN Eco IS NOT NULL AND LTRIM(RTRIM(Eco)) <> '' THEN Eco
+                   END) AS EcoDiversity
+            FROM PlayerGames;
+            """;
+
+        /// <summary>
+        /// Per-player distinct ECO count for corpus benchmarks (PLAN §12.7).
+        /// </summary>
+        public static string GetPerPlayerEcoDiversity =>
+            """
+            WITH FilteredGames AS
+            (
+                SELECT g.Id AS GameId,
+                       g.Eco,
+                       wp.Surname AS WhiteSurname,
+                       wp.Forenames AS WhiteForenames,
+                       bp.Surname AS BlackSurname,
+                       bp.Forenames AS BlackForenames
+                FROM dbo.Game g
+                INNER JOIN dbo.Player wp ON wp.Id = g.WhitePlayerId
+                INNER JOIN dbo.Player bp ON bp.Id = g.BlackPlayerId
+                WHERE (@MinGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear >= @MinGameYear))
+                  AND (@MaxGameYear IS NULL OR (g.GameYear IS NOT NULL AND g.GameYear <= @MaxGameYear))
+                  AND (@Eco IS NULL OR g.Eco = @Eco)
+            ),
+            Appearances AS
+            (
+                SELECT fg.GameId,
+                       fg.WhiteSurname AS PlayerSurname,
+                       fg.WhiteForenames AS PlayerForenames
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'White'
+
+                UNION ALL
+
+                SELECT fg.GameId,
+                       fg.BlackSurname,
+                       fg.BlackForenames
+                FROM FilteredGames fg
+                WHERE @PlayerColour = 'Any' OR @PlayerColour = 'Black'
+            )
+            SELECT a.PlayerSurname,
+                   a.PlayerForenames,
+                   COUNT(*) AS GameCount,
+                   COUNT(DISTINCT CASE
+                       WHEN fg.Eco IS NOT NULL AND LTRIM(RTRIM(fg.Eco)) <> '' THEN fg.Eco
+                   END) AS MetricValue
+            FROM Appearances a
+            INNER JOIN FilteredGames fg ON fg.GameId = a.GameId
+            GROUP BY a.PlayerSurname, a.PlayerForenames
+            ORDER BY MetricValue DESC, a.PlayerSurname, a.PlayerForenames;
+            """;
+
+        /// <summary>
         /// Games that have at least one board snapshot but no derived move rows yet (PLAN §5.3.5).
         /// </summary>
         public static string GetGameIdsNeedingAnalyticsBackfill =>

--- a/src/Services/Analytics/EcoDiversityExecutor.cs
+++ b/src/Services/Analytics/EcoDiversityExecutor.cs
@@ -1,0 +1,107 @@
+using Interfaces.Analytics;
+using Repositories;
+
+namespace Services.Analytics;
+
+/// <summary>
+/// Count of distinct ECO codes in games involving the filtered player (PLAN §12.6 Phase 8).
+/// </summary>
+public sealed class EcoDiversityExecutor(
+    IChessRepository repository,
+    ICorpusBenchmarkCalculator corpusBenchmarkCalculator) : IMetricExecutor
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    private readonly ICorpusBenchmarkCalculator _corpusBenchmarkCalculator =
+        corpusBenchmarkCalculator ?? throw new ArgumentNullException(nameof(corpusBenchmarkCalculator));
+
+    public string MetricKey => "EcoDiversity";
+
+    public async Task<AnalyticsTableResult> ExecuteAsync(AnalyticsQuery query, CancellationToken cancellationToken = default)
+    {
+        PlayerStyleMetricValidation.RequirePlayerFilter(query);
+        var rows = (await _repository.GetEcoDiversityAsync(query, cancellationToken).ConfigureAwait(false)).ToList();
+
+        if (CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query) && rows.Count > 0)
+        {
+            var perPlayer = await _repository
+                .GetPerPlayerEcoDiversityAsync(query, cancellationToken)
+                .ConfigureAwait(false);
+
+            var minGames = CorpusBenchmarkQueryDefaults.BenchmarkMinGames(query);
+            rows = rows
+                .Select(r => EnrichWithBenchmark(r, query, perPlayer, minGames))
+                .ToList();
+        }
+
+        var includeBenchmark = CorpusBenchmarkQueryDefaults.IncludeCorpusBenchmark(query);
+        return new AnalyticsTableResult
+        {
+            ColumnNames = includeBenchmark
+                ?
+                [
+                    "Player", "GameCount", "EcoDiversity",
+                    "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+                ]
+                : ["Player", "GameCount", "EcoDiversity"],
+            Rows = rows.Select(r => (IReadOnlyList<object?>)FormatRow(r, includeBenchmark).ToList()).ToList()
+        };
+    }
+
+    private EcoDiversityRow EnrichWithBenchmark(
+        EcoDiversityRow row,
+        AnalyticsQuery query,
+        IReadOnlyList<PlayerStylePerPlayerMetricRow> perPlayer,
+        int benchmarkMinGames)
+    {
+        var benchmark = _corpusBenchmarkCalculator.Compute(
+            row.EcoDiversity,
+            query.PlayerSurname!,
+            query.PlayerForenames,
+            perPlayer,
+            benchmarkMinGames);
+
+        return new EcoDiversityRow
+        {
+            PlayerSurname = row.PlayerSurname,
+            PlayerForenames = row.PlayerForenames,
+            GameCount = row.GameCount,
+            EcoDiversity = row.EcoDiversity,
+            CorpusAverage = benchmark.CorpusAverage,
+            DeltaFromCorpus = benchmark.DeltaFromCorpus,
+            CorpusPercentile = benchmark.CorpusPercentile,
+            CorpusEligiblePlayerCount = benchmark.CorpusEligiblePlayerCount
+        };
+    }
+
+    private static IReadOnlyList<object?> FormatRow(EcoDiversityRow r, bool includeBenchmark)
+    {
+        if (!includeBenchmark)
+        {
+            return
+            [
+                FormatPlayer(r),
+                r.GameCount,
+                r.EcoDiversity
+            ];
+        }
+
+        return
+        [
+            FormatPlayer(r),
+            r.GameCount,
+            r.EcoDiversity,
+            r.CorpusAverage,
+            r.DeltaFromCorpus,
+            r.CorpusPercentile,
+            r.CorpusEligiblePlayerCount
+        ];
+    }
+
+    private static string FormatPlayer(EcoDiversityRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.PlayerForenames))
+            return row.PlayerSurname;
+
+        return $"{row.PlayerSurname}, {row.PlayerForenames}";
+    }
+}

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -201,6 +201,14 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
         int shortDrawMaxPly,
         CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
 
+    public Task<IReadOnlyList<EcoDiversityRow>> GetEcoDiversityAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<EcoDiversityRow>>();
+
+    public Task<IReadOnlyList<PlayerStylePerPlayerMetricRow>> GetPerPlayerEcoDiversityAsync(
+        AnalyticsQuery query,
+        CancellationToken cancellationToken = default) => Throw<IReadOnlyList<PlayerStylePerPlayerMetricRow>>();
+
     public Task<IReadOnlyList<int>> GetGameIdsNeedingAnalyticsBackfillAsync(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<int>>();
 

--- a/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
+++ b/test/ServicesTests/Analytics/MetricRegistryAndExecutorsTests.cs
@@ -90,6 +90,10 @@ public class MetricRegistryAndExecutorsTests
             .ReturnsAsync(Array.Empty<ShortDrawRateRow>());
         repo.Setup(r => r.GetPerPlayerShortDrawRateAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
+        repo.Setup(r => r.GetEcoDiversityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<EcoDiversityRow>());
+        repo.Setup(r => r.GetPerPlayerEcoDiversityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PlayerStylePerPlayerMetricRow>());
 
         var sut = new MetricRegistry(new IMetricExecutor[]
         {
@@ -114,7 +118,8 @@ public class MetricRegistryAndExecutorsTests
             new UncastledKingRateExecutor(repo.Object, CorpusBenchmarkCalculator),
             new FirstQueenMovePlyExecutor(repo.Object, CorpusBenchmarkCalculator),
             new AverageGameLengthExecutor(repo.Object, CorpusBenchmarkCalculator),
-            new ShortDrawRateExecutor(repo.Object, CorpusBenchmarkCalculator)
+            new ShortDrawRateExecutor(repo.Object, CorpusBenchmarkCalculator),
+            new EcoDiversityExecutor(repo.Object, CorpusBenchmarkCalculator)
         });
 
         Assert.Contains("AverageMaterialByYearAndColour", sut.MetricKeys);
@@ -139,7 +144,8 @@ public class MetricRegistryAndExecutorsTests
         Assert.Contains("FirstQueenMovePly", sut.MetricKeys);
         Assert.Contains("AverageGameLength", sut.MetricKeys);
         Assert.Contains("ShortDrawRate", sut.MetricKeys);
-        Assert.Equal(22, sut.MetricKeys.Count);
+        Assert.Contains("EcoDiversity", sut.MetricKeys);
+        Assert.Equal(23, sut.MetricKeys.Count);
     }
 
     [Fact]
@@ -2192,6 +2198,118 @@ public class MetricRegistryAndExecutorsTests
         repo.Verify(r => r.GetShortDrawRateAsync(
             It.Is<AnalyticsQuery>(q => q.PlayerSurname == "Fischer" && q.ShortDrawMaxPly == 15),
             15,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EcoDiversityExecutor_MapsRow()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetEcoDiversityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<EcoDiversityRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GameCount = 200,
+                    EcoDiversity = 42
+                }
+            });
+
+        var sut = new EcoDiversityExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly"
+        });
+
+        Assert.Equal(["Player", "GameCount", "EcoDiversity"], result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal("Karpov, Anatoly", result.Rows[0][0]);
+        Assert.Equal(200, result.Rows[0][1]);
+        Assert.Equal(42, result.Rows[0][2]);
+    }
+
+    [Fact]
+    public async Task EcoDiversityExecutor_RequiresPlayerSurname()
+    {
+        var repo = new Mock<IChessRepository>();
+        var sut = new EcoDiversityExecutor(repo.Object, CorpusBenchmarkCalculator);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ExecuteAsync(new AnalyticsQuery()));
+    }
+
+    [Fact]
+    public async Task EcoDiversityExecutor_AppendsBenchmarkColumns_WhenRequested()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetEcoDiversityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<EcoDiversityRow>
+            {
+                new()
+                {
+                    PlayerSurname = "Karpov",
+                    PlayerForenames = "Anatoly",
+                    GameCount = 100,
+                    EcoDiversity = 25
+                }
+            });
+        repo.Setup(r => r.GetPerPlayerEcoDiversityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PlayerStylePerPlayerMetricRow>
+            {
+                new() { PlayerSurname = "Karpov", PlayerForenames = "Anatoly", GameCount = 100, MetricValue = 25 },
+                new() { PlayerSurname = "Petrosian", PlayerForenames = "Tigran", GameCount = 90, MetricValue = 15 },
+                new() { PlayerSurname = "Tal", PlayerForenames = "Mikhail", GameCount = 80, MetricValue = 20 }
+            });
+
+        var sut = new EcoDiversityExecutor(repo.Object, CorpusBenchmarkCalculator);
+        var result = await sut.ExecuteAsync(new AnalyticsQuery
+        {
+            PlayerSurname = "Karpov",
+            PlayerForenames = "Anatoly",
+            IncludeCorpusBenchmark = true,
+            BenchmarkMinGames = 30
+        });
+
+        Assert.Equal(
+            [
+                "Player", "GameCount", "EcoDiversity",
+                "CorpusAverage", "DeltaFromCorpus", "CorpusPercentile", "CorpusEligiblePlayerCount"
+            ],
+            result.ColumnNames);
+        Assert.Single(result.Rows);
+        Assert.Equal(25, result.Rows[0][2]);
+        Assert.Equal(17.5, (double)result.Rows[0][3]!, precision: 10);
+        Assert.Equal(7.5, (double)result.Rows[0][4]!, precision: 10);
+        Assert.Equal(100.0, result.Rows[0][5]);
+        Assert.Equal(2, result.Rows[0][6]);
+    }
+
+    [Fact]
+    public async Task EcoDiversityExecutor_PassesFiltersToRepository()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetEcoDiversityAsync(It.IsAny<AnalyticsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<EcoDiversityRow>());
+
+        var query = new AnalyticsQuery
+        {
+            PlayerSurname = "Fischer",
+            PlayerForenames = "Bobby",
+            PlayerColour = "White",
+            MinGameYear = 1970
+        };
+        var sut = new EcoDiversityExecutor(repo.Object, CorpusBenchmarkCalculator);
+
+        await sut.ExecuteAsync(query);
+
+        repo.Verify(r => r.GetEcoDiversityAsync(
+            It.Is<AnalyticsQuery>(q =>
+                q.PlayerSurname == "Fischer"
+                && q.PlayerForenames == "Bobby"
+                && q.PlayerColour == "White"
+                && q.MinGameYear == 1970),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary

- Add **`EcoDiversity`** style metric (PLAN §12.6 Phase 8): `COUNT(DISTINCT Eco)` over filtered player appearances; null/blank ECO excluded from the count.
- Includes executor, SQL, repository methods, corpus benchmark support, UI checkbox, `MetricCatalog` entries, and tests.

## Test plan

- [x] `dotnet test` (506 passed)
- [ ] Run metric for a player with a broad repertoire and sanity-check `EcoDiversity`
