### PR TITLE
feat: add WasWorldChampion player metadata

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (`EcoDiversity` metric — PR in flight.)
+**Last updated:** 2026-06-11 (player metadata — world champion flag).
 
 ---
 
@@ -35,7 +35,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (Phase 5):** `UncastledKingRate` (PR #62).
 - **Done (Phase 6):** `FirstQueenMovePly`.
 - **Done (Phase 7):** `AverageGameLength`, `ShortDrawRate`.
-- **Done (Phase 8):** `EcoDiversity` (PR in flight).
+- **Done (Phase 8):** `EcoDiversity`.
+- **Done (player metadata):** `WasWorldChampion` on `dbo.Player` (PR in flight).
 - **Done (corpus benchmarks):** `CentreMoveRate`, `ForwardMoveRate`, `CastlingSidePreference`, `OppositeSideCastlingRate`, `UncastledKingRate`, `FirstQueenMovePly`, `AverageGameLength`, `ShortDrawRate`, `EcoDiversity`.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §12.4).
 

--- a/src/Analyser/Controllers/AnalyserController.cs
+++ b/src/Analyser/Controllers/AnalyserController.cs
@@ -116,7 +116,8 @@ public class AnalyserController(
                 Id = p.Id,
                 Surname = p.Surname?.Trim() ?? string.Empty,
                 Forenames = p.Forenames?.Trim() ?? string.Empty,
-                DisplayName = FormatPlayerDisplayName(p)
+                DisplayName = FormatPlayerDisplayName(p),
+                WasWorldChampion = p.WasWorldChampion
             })
             .ToList();
 
@@ -210,8 +211,9 @@ public class AnalyserController(
         if (surname.Length == 0)
             return forenames.Length == 0 ? $"Player {player.Id}" : forenames;
         if (forenames.Length == 0)
-            return surname;
+            return player.WasWorldChampion ? $"{surname} (WC)" : surname;
 
-        return $"{surname}, {forenames}";
+        var baseName = $"{surname}, {forenames}";
+        return player.WasWorldChampion ? $"{baseName} (WC)" : baseName;
     }
 }

--- a/src/Analyser/Models/PlayerOptionResponse.cs
+++ b/src/Analyser/Models/PlayerOptionResponse.cs
@@ -12,4 +12,6 @@ public sealed class PlayerOptionResponse
     public required string Forenames { get; init; }
 
     public required string DisplayName { get; init; }
+
+    public bool WasWorldChampion { get; init; }
 }

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -1,5 +1,6 @@
 using Analyser;
 using Interfaces.Analytics;
+using Interfaces.DTO;
 using Microsoft.OpenApi.Models;
 using Repositories;
 using Services;
@@ -61,6 +62,7 @@ builder.Services.AddScoped<IDisplayService, DisplayService>();
 builder.Services.AddScoped<IBoardPositionsHelper, BoardPositionsHelper>();
 builder.Services.AddScoped<IPersistenceService, PersistenceService>();
 builder.Services.AddScoped<IPlayerResolver, PlayerResolver>();
+builder.Services.AddScoped<IPlayerMetadataSyncService, PlayerMetadataSyncService>();
 builder.Services.AddScoped<IMoveInterpreter, MoveInterpreter>();
 builder.Services.AddScoped<IBoardPositionService, BoardPositionService>();
 builder.Services.AddScoped<IMoveInterpreterHelper, MoveInterpreterHelper>();
@@ -147,6 +149,16 @@ if (args.Any(a => string.Equals(a, "--profile-materialization", StringComparison
         $"{result.GamesPerSecond:F0} games/s, {result.DerivedRowsPerSecond:F0} summary+move rows/s " +
         $"({result.SummaryRowsPerIteration} summaries + {result.MoveRowsPerIteration} move per game). " +
         $"See docs/ANALYTICS_MATERIALIZATION_PERF.md for methodology (PLAN §11 item 12 / DESIGN NFR-3).");
+    return;
+}
+
+if (args.Any(a => string.Equals(a, "--sync-player-metadata", StringComparison.OrdinalIgnoreCase)))
+{
+    await using var scope = app.Services.CreateAsyncScope();
+    var sync = scope.ServiceProvider.GetRequiredService<IPlayerMetadataSyncService>();
+    var outcome = await sync.SyncWorldChampionFlagsAsync();
+    Console.WriteLine(
+        $"Player metadata sync: checked={outcome.PlayersChecked}, updated={outcome.PlayersUpdated}.");
     return;
 }
 

--- a/src/Analyser/wwwroot/index.html
+++ b/src/Analyser/wwwroot/index.html
@@ -262,6 +262,8 @@
           var opt = document.createElement('option');
           opt.value = p.displayName || (p.surname || ('Player ' + p.id));
           opt.textContent = p.displayName || ('Player ' + p.id);
+          if (p.wasWorldChampion)
+            opt.title = 'World champion';
           opt.dataset.surname = p.surname || '';
           opt.dataset.forenames = p.forenames || '';
           select.appendChild(opt);

--- a/src/Interfaces/DTO/IPlayerMetadataSyncService.cs
+++ b/src/Interfaces/DTO/IPlayerMetadataSyncService.cs
@@ -1,0 +1,12 @@
+namespace Interfaces.DTO;
+
+/// <summary>
+/// Applies curated metadata (world champion, etc.) to persisted player rows.
+/// </summary>
+public interface IPlayerMetadataSyncService
+{
+    /// <summary>
+    /// Recomputes <see cref="Player.WasWorldChampion"/> for every player from the in-app catalog.
+    /// </summary>
+    Task<PlayerMetadataSyncResult> SyncWorldChampionFlagsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Interfaces/DTO/Player.cs
+++ b/src/Interfaces/DTO/Player.cs
@@ -12,5 +12,8 @@ namespace Interfaces.DTO
 
         /// <summary>Forenames (given names). No leading or trailing spaces. May be empty.</summary>
         public string Forenames { get; set; } = string.Empty;
+
+        /// <summary>True when this player has held the classical world championship (curated catalog).</summary>
+        public bool WasWorldChampion { get; set; }
     }
 }

--- a/src/Interfaces/DTO/PlayerMetadataSyncResult.cs
+++ b/src/Interfaces/DTO/PlayerMetadataSyncResult.cs
@@ -1,0 +1,11 @@
+namespace Interfaces.DTO;
+
+/// <summary>
+/// Outcome of synchronising curated player metadata (e.g. world-champion flag) onto dbo.Player rows.
+/// </summary>
+public sealed class PlayerMetadataSyncResult
+{
+    public int PlayersChecked { get; init; }
+
+    public int PlayersUpdated { get; init; }
+}

--- a/src/Migrations/History/current/tables/dbo.Player.sql
+++ b/src/Migrations/History/current/tables/dbo.Player.sql
@@ -4,6 +4,7 @@ CREATE TABLE [dbo].[Player](
 	[Id] [int] IDENTITY(1,1) NOT NULL,
 	[Surname] [nvarchar](200) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
 	[Forenames] [nvarchar](400) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
+	[WasWorldChampion] [bit] NOT NULL,
  CONSTRAINT [PK_Player] PRIMARY KEY CLUSTERED 
 (
 	[Id] ASC
@@ -16,3 +17,4 @@ CREATE TABLE [dbo].[Player](
 ) ON [PRIMARY]
 
 ALTER TABLE [dbo].[Player] ADD  DEFAULT (N'') FOR [Forenames]
+ALTER TABLE [dbo].[Player] ADD  DEFAULT ((0)) FOR [WasWorldChampion]

--- a/src/Migrations/History/current/tables/dbo.Player.sql
+++ b/src/Migrations/History/current/tables/dbo.Player.sql
@@ -17,4 +17,4 @@ CREATE TABLE [dbo].[Player](
 ) ON [PRIMARY]
 
 ALTER TABLE [dbo].[Player] ADD  DEFAULT (N'') FOR [Forenames]
-ALTER TABLE [dbo].[Player] ADD  DEFAULT ((0)) FOR [WasWorldChampion]
+ALTER TABLE [dbo].[Player] ADD  CONSTRAINT [DF_Player_WasWorldChampion]  DEFAULT ((0)) FOR [WasWorldChampion]

--- a/src/Migrations/README.md
+++ b/src/Migrations/README.md
@@ -37,6 +37,7 @@ Ensure the **database** (e.g. `Chess`) already exists; DbUp does not create it. 
 | `008_CreateGamePositionSummaryTable.sql` | Creates `dbo.GamePositionSummary` rollup table (material + piece-count scalars per ply) for analytics reads without bitboard decoding. |
 | `009_CreateDeleteGameStoredProcedure.sql` | Creates `dbo.DeleteGameById` to delete a game and dependent rows in one explicit transaction (instead of FK cascades on analytics tables). |
 | `010_RemoveCascadeDeletesFromGameDependencies.sql` | Enforces strict no-cascade FKs from `BoardPosition`, `GameMove`, and `GamePositionSummary` to `Game` (drops/recreates FK if cascade is present). |
+| `011_AddPlayerWasWorldChampionColumn.sql` | Adds `WasWorldChampion` bit on `dbo.Player` (curated classical world-champion metadata). |
 
 `BoardPosition` uses `PlyIndex`: **-1** = initial position, **0, 1, 2, ...** = position after each ply. Columns `WP`, `WN`, … `BK` store 64-bit bitboards as `BIGINT`.
 
@@ -48,6 +49,7 @@ Ensure the **database** (e.g. `Chess`) already exists; DbUp does not create it. 
 
 - **Perf smoke (CPU-only, NFR-3):** [docs/ANALYTICS_MATERIALIZATION_PERF.md](../../docs/ANALYTICS_MATERIALIZATION_PERF.md) — `dotnet run --project src/Analyser -- --profile-materialization` (optional `--iterations N`).
 - **Backfill gaps:** `dotnet run --project src/Analyser -- --backfill-analytics` (optional `--max-games N`) for games that have `BoardPosition` rows but no `GameMove` rows yet.
+- **Player metadata:** after migration `011`, run `dotnet run --project src/Analyser -- --sync-player-metadata` to apply the world-champion catalog to existing `dbo.Player` rows. New players pick up the flag on insert during ETL.
 
 ## Schema history snapshot
 

--- a/src/Migrations/Scripts/011_AddPlayerWasWorldChampionColumn.sql
+++ b/src/Migrations/Scripts/011_AddPlayerWasWorldChampionColumn.sql
@@ -1,0 +1,8 @@
+-- Idempotent: add WasWorldChampion flag to dbo.Player.
+IF COL_LENGTH(N'dbo.Player', N'WasWorldChampion') IS NULL
+BEGIN
+    ALTER TABLE dbo.Player
+        ADD WasWorldChampion BIT NOT NULL
+            CONSTRAINT DF_Player_WasWorldChampion DEFAULT (0);
+END
+GO

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -36,6 +36,9 @@ namespace Repositories
 
         Task<int> InsertPlayer(Player player);
 
+        /// <summary>Updates the world-champion metadata flag for a player row.</summary>
+        Task UpdatePlayerWasWorldChampionAsync(int playerId, bool wasWorldChampion, CancellationToken cancellationToken = default);
+
         Task<int> InsertGame(Game game);
 
         /// <summary>
@@ -515,9 +518,28 @@ namespace Repositories
             using var connection = GetOpenConnection();
             using (connection)
             {
-                var id = await connection.ExecuteScalarAsync<int>(SqlStatements.InsertPlayer, new { player.Surname, player.Forenames });
+                var id = await connection.ExecuteScalarAsync<int>(SqlStatements.InsertPlayer, new
+                {
+                    player.Surname,
+                    player.Forenames,
+                    player.WasWorldChampion
+                });
                 return id;
             }
+        }
+
+        /// <inheritdoc />
+        public async Task UpdatePlayerWasWorldChampionAsync(
+            int playerId,
+            bool wasWorldChampion,
+            CancellationToken cancellationToken = default)
+        {
+            using var connection = GetOpenConnection();
+            await connection.ExecuteAsync(
+                new CommandDefinition(
+                    SqlStatements.UpdatePlayerWasWorldChampion,
+                    new { Id = playerId, WasWorldChampion = wasWorldChampion },
+                    cancellationToken: cancellationToken));
         }
 
         public async Task<List<string>> GetProcessedGameIds()

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -7,18 +7,26 @@ namespace Repositories
 		}
 
         public static string GetPlayers =>
-            "SELECT Id, Surname, Forenames FROM dbo.Player;";
+            "SELECT Id, Surname, Forenames, WasWorldChampion FROM dbo.Player;";
 
         public static string GetPlayerIdBySurnameAndForenames =>
             "SELECT Id FROM dbo.Player WHERE Surname = @Surname AND Forenames = @Forenames;";
 
         public static string GetPlayersBySurname =>
-            "SELECT Id, Surname, Forenames FROM dbo.Player WHERE LOWER(Surname) = LOWER(@Surname);";
+            "SELECT Id, Surname, Forenames, WasWorldChampion FROM dbo.Player WHERE LOWER(Surname) = LOWER(@Surname);";
 
         public static string InsertPlayer =>
             """
-            INSERT INTO dbo.Player (Surname, Forenames) VALUES (@Surname, @Forenames);
+            INSERT INTO dbo.Player (Surname, Forenames, WasWorldChampion)
+            VALUES (@Surname, @Forenames, @WasWorldChampion);
             SELECT CAST(SCOPE_IDENTITY() AS INT);
+            """;
+
+        public static string UpdatePlayerWasWorldChampion =>
+            """
+            UPDATE dbo.Player
+            SET WasWorldChampion = @WasWorldChampion
+            WHERE Id = @Id;
             """;
 
         public static string InsertGame =>

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -27,6 +27,9 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
 
     public Task<int> InsertPlayer(Player player) => Throw<int>();
 
+    public Task UpdatePlayerWasWorldChampionAsync(int playerId, bool wasWorldChampion, CancellationToken cancellationToken = default) =>
+        Throw();
+
     public Task<int> InsertGame(Game game) => Throw<int>();
 
     public Task InsertBoardPositions(Game game, int gameId) => Throw();

--- a/src/Services/PlayerMetadata/WorldChampionCatalog.cs
+++ b/src/Services/PlayerMetadata/WorldChampionCatalog.cs
@@ -1,0 +1,51 @@
+using Services.Helpers;
+
+namespace Services.PlayerMetadata;
+
+/// <summary>
+/// Curated list of classical world champions matched against stored (Surname, Forenames) using
+/// <see cref="PlayerForenamesMatcher"/> for abbreviation tolerance.
+/// </summary>
+public static class WorldChampionCatalog
+{
+    private static readonly (string Surname, string Forenames)[] Champions =
+    [
+        ("Steinitz", "Wilhelm"),
+        ("Lasker", "Emanuel"),
+        ("Capablanca", "Jose Raul"),
+        ("Alekhine", "Alexander"),
+        ("Euwe", "Max"),
+        ("Botvinnik", "Mikhail"),
+        ("Smyslov", "Vasily"),
+        ("Tal", "Mikhail"),
+        ("Petrosian", "Tigran"),
+        ("Spassky", "Boris"),
+        ("Fischer", "Bobby"),
+        ("Fischer", "Robert James"),
+        ("Karpov", "Anatoly"),
+        ("Kasparov", "Garry"),
+        ("Kramnik", "Vladimir"),
+        ("Anand", "Viswanathan"),
+        ("Carlsen", "Magnus"),
+        ("Ding", "Liren"),
+        ("Gukesh", "Dommaraju"),
+    ];
+
+    public static bool IsWorldChampion(string surname, string? forenames)
+    {
+        if (string.IsNullOrWhiteSpace(surname))
+            return false;
+
+        var normalizedForenames = (forenames ?? string.Empty).Trim();
+        foreach (var (championSurname, championForenames) in Champions)
+        {
+            if (!string.Equals(championSurname, surname.Trim(), StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (PlayerForenamesMatcher.ForenamesMatch(championForenames, normalizedForenames))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Services/PlayerMetadataSyncService.cs
+++ b/src/Services/PlayerMetadataSyncService.cs
@@ -1,0 +1,36 @@
+using Interfaces.DTO;
+using Repositories;
+using Services.PlayerMetadata;
+
+namespace Services;
+
+/// <inheritdoc />
+public sealed class PlayerMetadataSyncService(IChessRepository repository) : IPlayerMetadataSyncService
+{
+    private readonly IChessRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    /// <inheritdoc />
+    public async Task<PlayerMetadataSyncResult> SyncWorldChampionFlagsAsync(CancellationToken cancellationToken = default)
+    {
+        var players = await _repository.GetPlayers().ConfigureAwait(false);
+        var updated = 0;
+
+        foreach (var player in players)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var shouldBeChampion = WorldChampionCatalog.IsWorldChampion(player.Surname, player.Forenames);
+            if (player.WasWorldChampion == shouldBeChampion)
+                continue;
+
+            await _repository.UpdatePlayerWasWorldChampionAsync(player.Id, shouldBeChampion, cancellationToken)
+                .ConfigureAwait(false);
+            updated++;
+        }
+
+        return new PlayerMetadataSyncResult
+        {
+            PlayersChecked = players.Count,
+            PlayersUpdated = updated
+        };
+    }
+}

--- a/src/Services/PlayerResolver.cs
+++ b/src/Services/PlayerResolver.cs
@@ -1,6 +1,7 @@
 using Interfaces.DTO;
 using Repositories;
 using Services.Helpers;
+using Services.PlayerMetadata;
 
 namespace Services
 {
@@ -75,7 +76,12 @@ namespace Services
                     return p.Id;
                 }
             }
-            var player = new Player { Surname = surname, Forenames = forenamesNorm };
+            var player = new Player
+            {
+                Surname = surname,
+                Forenames = forenamesNorm,
+                WasWorldChampion = WorldChampionCatalog.IsWorldChampion(surname, forenamesNorm)
+            };
             id = await _chessRepository.InsertPlayer(player);
             _cache[key] = id;
             return id;

--- a/test/AnalyserTests/AnalyserControllerTests.cs
+++ b/test/AnalyserTests/AnalyserControllerTests.cs
@@ -93,9 +93,9 @@ namespace ControllerTests
         {
             var players = new List<Player>
             {
-                new() { Id = 2, Surname = "Tal", Forenames = "Mikhail" },
-                new() { Id = 1, Surname = "Botvinnik", Forenames = "Mikhail" },
-                new() { Id = 3, Surname = "Capablanca", Forenames = "" }
+                new() { Id = 2, Surname = "Tal", Forenames = "Mikhail", WasWorldChampion = true },
+                new() { Id = 1, Surname = "Botvinnik", Forenames = "Mikhail", WasWorldChampion = true },
+                new() { Id = 3, Surname = "Capablanca", Forenames = "", WasWorldChampion = false }
             };
             var chessRepoMock = new Mock<IChessRepository>();
             chessRepoMock.Setup(r => r.GetPlayers()).ReturnsAsync(players);
@@ -118,9 +118,12 @@ namespace ControllerTests
             Assert.Equal([1, 3, 2], options.Select(o => o.Id).ToArray());
             Assert.Equal("Botvinnik", options[0].Surname);
             Assert.Equal("Mikhail", options[0].Forenames);
-            Assert.Equal("Botvinnik, Mikhail", options[0].DisplayName);
+            Assert.Equal("Botvinnik, Mikhail (WC)", options[0].DisplayName);
+            Assert.True(options[0].WasWorldChampion);
             Assert.Equal("Capablanca", options[1].DisplayName);
-            Assert.Equal("Tal, Mikhail", options[2].DisplayName);
+            Assert.False(options[1].WasWorldChampion);
+            Assert.Equal("Tal, Mikhail (WC)", options[2].DisplayName);
+            Assert.True(options[2].WasWorldChampion);
         }
 
         [Fact]

--- a/test/ServicesTests/PlayerMetadata/PlayerMetadataSyncServiceTests.cs
+++ b/test/ServicesTests/PlayerMetadata/PlayerMetadataSyncServiceTests.cs
@@ -1,0 +1,30 @@
+using Interfaces.DTO;
+using Moq;
+using Repositories;
+using Services;
+
+namespace ServicesTests.PlayerMetadata;
+
+public class PlayerMetadataSyncServiceTests
+{
+    [Fact]
+    public async Task SyncWorldChampionFlagsAsync_UpdatesOnlyChangedRows()
+    {
+        var repo = new Mock<IChessRepository>();
+        repo.Setup(r => r.GetPlayers()).ReturnsAsync(new List<Player>
+        {
+            new() { Id = 1, Surname = "Kasparov", Forenames = "Garry", WasWorldChampion = false },
+            new() { Id = 2, Surname = "Tal", Forenames = "Mikhail", WasWorldChampion = true },
+            new() { Id = 3, Surname = "Morphy", Forenames = "Paul", WasWorldChampion = false }
+        });
+
+        var sut = new PlayerMetadataSyncService(repo.Object);
+        var result = await sut.SyncWorldChampionFlagsAsync();
+
+        Assert.Equal(3, result.PlayersChecked);
+        Assert.Equal(1, result.PlayersUpdated);
+        repo.Verify(r => r.UpdatePlayerWasWorldChampionAsync(1, true, It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.UpdatePlayerWasWorldChampionAsync(2, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.UpdatePlayerWasWorldChampionAsync(3, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/test/ServicesTests/PlayerMetadata/WorldChampionCatalogTests.cs
+++ b/test/ServicesTests/PlayerMetadata/WorldChampionCatalogTests.cs
@@ -1,0 +1,22 @@
+using Services.PlayerMetadata;
+
+namespace ServicesTests.PlayerMetadata;
+
+public class WorldChampionCatalogTests
+{
+    [Theory]
+    [InlineData("Kasparov", "Garry", true)]
+    [InlineData("Carlsen", "Magnus", true)]
+    [InlineData("Fischer", "Bobby", true)]
+    [InlineData("Fischer", "Robert", true)]
+    [InlineData("Capablanca", "Jose Raul", true)]
+    [InlineData("Tal", "Mikhail", true)]
+    [InlineData("Ding", "Liren", true)]
+    [InlineData("Gukesh", "Dommaraju", true)]
+    [InlineData("Morphy", "Paul", false)]
+    [InlineData("Kasparov", "", false)]
+    public void IsWorldChampion_MatchesCuratedChampions(string surname, string forenames, bool expected)
+    {
+        Assert.Equal(expected, WorldChampionCatalog.IsWorldChampion(surname, forenames));
+    }
+}


### PR DESCRIPTION
## Summary

- Add **`WasWorldChampion`** bit column on `dbo.Player` (migration `011`).
- Curated **`WorldChampionCatalog`** (classical champions) matched via existing forename abbreviation logic.
- New players get the flag on ETL insert; **`--sync-player-metadata`** backfills existing rows.
- **`GetPlayers`** API / UI dropdown expose `wasWorldChampion` and append `(WC)` to display names.

## Test plan

- [x] `dotnet test` (527 passed)
- [ ] Run migration `011`, then `dotnet run --project src/Analyser -- --sync-player-metadata`
- [ ] Confirm known champions show `(WC)` in player dropdowns
