### PR TITLE
feat: add FIDE metadata columns on Player (PLAN §15.1)

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (DESIGN §13 / PLAN §15 — player metadata draft).
+**Last updated:** 2026-06-11 (PLAN §15.1 — player FIDE columns).
 
 ---
 
@@ -28,7 +28,8 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (style metrics Phases 1–8 except EcoConcentration):** through **`EcoDiversity`**; **`EcoConcentration`** unchecked (§12.6 item 16).
 - **Done (corpus benchmarks):** all benchmark-enabled style metrics through Phase 8.
 - **Done (player metadata v0):** `WasWorldChampion` on `dbo.Player`, `WorldChampionCatalog`, `--sync-player-metadata` (PR #70).
-- **In design (not implemented):** [DESIGN §13](./DESIGN.md) / [PLAN §15](./PLAN.md) — FIDE enrichment columns, `--sync-fide-metadata`, metadata filters.
+- **Done (player metadata v1 schema):** FIDE columns on `dbo.Player` + `UpdatePlayerFideMetadataAsync` (PLAN §15.1, branch `feat/player-fide-columns`).
+- **Next (player metadata):** PLAN §15.2 FIDE list reader + matcher.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §13).
 
 ---
@@ -48,9 +49,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next:** [PLAN §15.1](./PLAN.md) — migration **`012`** + DTO/repo for **`FideId`**, **`Federation`**, **`Sex`**, **`FideTitle`**, **`BirthYear`** on `dbo.Player` (schema only, no sync yet).
+**Do next:** [PLAN §15.2](./PLAN.md) — FIDE TXT reader + **`IFidePlayerMatcher`**.
 
-**Then (in order):** §15.2 FIDE matcher → §15.3 `--sync-fide-metadata` CLI → §15.4 API → §15.5–15.7 filters.
+**Then (in order):** §15.3 `--sync-fide-metadata` CLI → §15.4 API → §15.5–15.7 filters.
 
 **Parallel / after enrichment usable:** §12.6 **`EcoConcentration`** when maintainer wants style metrics again.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -711,17 +711,17 @@ player (e.g. Petrosian) on the same filters.
 
 **Branch:** `feat/player-fide-columns`
 
-1. [ ] Migration **`012_AddPlayerFideMetadataColumns.sql`** (idempotent `ALTER`):
+1. [x] Migration **`012_AddPlayerFideMetadataColumns.sql`** (idempotent `ALTER`):
    - `FideId INT NULL`
    - `Federation CHAR(3) NULL`
    - `Sex CHAR(1) NULL`
    - `FideTitle NVARCHAR(8) NULL`
    - `BirthYear SMALLINT NULL`
    - Unique filtered index: `UX_Player_FideId` ON `(FideId)` WHERE `FideId IS NOT NULL`
-2. [ ] Update **`Migrations/History/current/tables/dbo.Player.sql`** exporter snapshot.
-3. [ ] Extend **`Interfaces/DTO/Player.cs`**, **`SqlStatements`** (select/insert/update player).
-4. [ ] Repository methods: `UpdatePlayerFideMetadataAsync` (or single update DTO).
-5. [ ] Unit tests: DTO mapping / SQL parameter round-trip (mock repo or integration if pattern exists).
+2. [x] Update **`Migrations/History/current/tables/dbo.Player.sql`** exporter snapshot.
+3. [x] Extend **`Interfaces/DTO/Player.cs`**, **`SqlStatements`** (select/insert/update player).
+4. [x] Repository methods: `UpdatePlayerFideMetadataAsync` (or single update DTO).
+5. [x] Unit tests: DTO mapping / SQL parameter round-trip (mock repo or integration if pattern exists).
 
 **Acceptance:** `dotnet test` passes; existing ETL unchanged; new columns NULL for all players.
 

--- a/src/Interfaces/DTO/Player.cs
+++ b/src/Interfaces/DTO/Player.cs
@@ -15,5 +15,20 @@ namespace Interfaces.DTO
 
         /// <summary>True when this player has held the classical world championship (curated catalog).</summary>
         public bool WasWorldChampion { get; set; }
+
+        /// <summary>FIDE player ID when matched from an official rating list; null when unknown.</summary>
+        public int? FideId { get; set; }
+
+        /// <summary>Three-letter federation code from FIDE (e.g. NOR, IND).</summary>
+        public string? Federation { get; set; }
+
+        /// <summary>M or F when known from FIDE.</summary>
+        public string? Sex { get; set; }
+
+        /// <summary>Highest FIDE title when known: GM, IM, WGM, FM, WFM, CM, WCM.</summary>
+        public string? FideTitle { get; set; }
+
+        /// <summary>Birth year from FIDE when known.</summary>
+        public short? BirthYear { get; set; }
     }
 }

--- a/src/Interfaces/DTO/PlayerFideMetadata.cs
+++ b/src/Interfaces/DTO/PlayerFideMetadata.cs
@@ -1,0 +1,20 @@
+namespace Interfaces.DTO;
+
+/// <summary>
+/// FIDE-sourced attributes for a <see cref="Player"/> row (DESIGN §13.3).
+/// </summary>
+public sealed class PlayerFideMetadata
+{
+    public int? FideId { get; init; }
+
+    /// <summary>Three-letter federation code (e.g. NOR, IND).</summary>
+    public string? Federation { get; init; }
+
+    /// <summary>M or F when known.</summary>
+    public string? Sex { get; init; }
+
+    /// <summary>Normalised title: GM, IM, WGM, FM, WFM, CM, WCM.</summary>
+    public string? FideTitle { get; init; }
+
+    public short? BirthYear { get; init; }
+}

--- a/src/Migrations/History/current/tables/dbo.Player.sql
+++ b/src/Migrations/History/current/tables/dbo.Player.sql
@@ -5,6 +5,11 @@ CREATE TABLE [dbo].[Player](
 	[Surname] [nvarchar](200) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
 	[Forenames] [nvarchar](400) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
 	[WasWorldChampion] [bit] NOT NULL,
+	[FideId] [int] NULL,
+	[Federation] [char](3) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[Sex] [char](1) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[FideTitle] [nvarchar](8) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+	[BirthYear] [smallint] NULL,
  CONSTRAINT [PK_Player] PRIMARY KEY CLUSTERED 
 (
 	[Id] ASC
@@ -16,5 +21,11 @@ CREATE TABLE [dbo].[Player](
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY]
 
+CREATE UNIQUE NONCLUSTERED INDEX [UX_Player_FideId] ON [dbo].[Player]
+(
+	[FideId] ASC
+)
+WHERE ([FideId] IS NOT NULL)
+WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
 ALTER TABLE [dbo].[Player] ADD  DEFAULT (N'') FOR [Forenames]
 ALTER TABLE [dbo].[Player] ADD  CONSTRAINT [DF_Player_WasWorldChampion]  DEFAULT ((0)) FOR [WasWorldChampion]

--- a/src/Migrations/README.md
+++ b/src/Migrations/README.md
@@ -38,6 +38,7 @@ Ensure the **database** (e.g. `Chess`) already exists; DbUp does not create it. 
 | `009_CreateDeleteGameStoredProcedure.sql` | Creates `dbo.DeleteGameById` to delete a game and dependent rows in one explicit transaction (instead of FK cascades on analytics tables). |
 | `010_RemoveCascadeDeletesFromGameDependencies.sql` | Enforces strict no-cascade FKs from `BoardPosition`, `GameMove`, and `GamePositionSummary` to `Game` (drops/recreates FK if cascade is present). |
 | `011_AddPlayerWasWorldChampionColumn.sql` | Adds `WasWorldChampion` bit on `dbo.Player` (curated classical world-champion metadata). |
+| `012_AddPlayerFideMetadataColumns.sql` | Adds nullable FIDE metadata on `dbo.Player` (`FideId`, `Federation`, `Sex`, `FideTitle`, `BirthYear`) and unique filtered index on `FideId`. |
 
 `BoardPosition` uses `PlyIndex`: **-1** = initial position, **0, 1, 2, ...** = position after each ply. Columns `WP`, `WN`, … `BK` store 64-bit bitboards as `BIGINT`.
 

--- a/src/Migrations/Scripts/012_AddPlayerFideMetadataColumns.sql
+++ b/src/Migrations/Scripts/012_AddPlayerFideMetadataColumns.sql
@@ -1,0 +1,27 @@
+-- Idempotent: FIDE-sourced metadata columns on dbo.Player (DESIGN §13, PLAN §15.1).
+
+IF OBJECT_ID(N'dbo.Player', N'U') IS NOT NULL
+BEGIN
+    IF COL_LENGTH(N'dbo.Player', N'FideId') IS NULL
+        ALTER TABLE dbo.Player ADD FideId INT NULL;
+
+    IF COL_LENGTH(N'dbo.Player', N'Federation') IS NULL
+        ALTER TABLE dbo.Player ADD Federation CHAR(3) NULL;
+
+    IF COL_LENGTH(N'dbo.Player', N'Sex') IS NULL
+        ALTER TABLE dbo.Player ADD Sex CHAR(1) NULL;
+
+    IF COL_LENGTH(N'dbo.Player', N'FideTitle') IS NULL
+        ALTER TABLE dbo.Player ADD FideTitle NVARCHAR(8) NULL;
+
+    IF COL_LENGTH(N'dbo.Player', N'BirthYear') IS NULL
+        ALTER TABLE dbo.Player ADD BirthYear SMALLINT NULL;
+END
+GO
+
+IF OBJECT_ID(N'dbo.Player', N'U') IS NOT NULL
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID(N'dbo.Player') AND name = N'UX_Player_FideId')
+        CREATE UNIQUE NONCLUSTERED INDEX UX_Player_FideId ON dbo.Player (FideId) WHERE FideId IS NOT NULL;
+END
+GO

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -39,6 +39,9 @@ namespace Repositories
         /// <summary>Updates the world-champion metadata flag for a player row.</summary>
         Task UpdatePlayerWasWorldChampionAsync(int playerId, bool wasWorldChampion, CancellationToken cancellationToken = default);
 
+        /// <summary>Updates FIDE-sourced metadata columns for a player row (DESIGN §13.3).</summary>
+        Task UpdatePlayerFideMetadataAsync(int playerId, PlayerFideMetadata metadata, CancellationToken cancellationToken = default);
+
         Task<int> InsertGame(Game game);
 
         /// <summary>
@@ -539,6 +542,29 @@ namespace Repositories
                 new CommandDefinition(
                     SqlStatements.UpdatePlayerWasWorldChampion,
                     new { Id = playerId, WasWorldChampion = wasWorldChampion },
+                    cancellationToken: cancellationToken));
+        }
+
+        /// <inheritdoc />
+        public async Task UpdatePlayerFideMetadataAsync(
+            int playerId,
+            PlayerFideMetadata metadata,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(metadata);
+            using var connection = GetOpenConnection();
+            await connection.ExecuteAsync(
+                new CommandDefinition(
+                    SqlStatements.UpdatePlayerFideMetadata,
+                    new
+                    {
+                        Id = playerId,
+                        metadata.FideId,
+                        metadata.Federation,
+                        metadata.Sex,
+                        metadata.FideTitle,
+                        metadata.BirthYear
+                    },
                     cancellationToken: cancellationToken));
         }
 

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -7,13 +7,22 @@ namespace Repositories
 		}
 
         public static string GetPlayers =>
-            "SELECT Id, Surname, Forenames, WasWorldChampion FROM dbo.Player;";
+            """
+            SELECT Id, Surname, Forenames, WasWorldChampion,
+                   FideId, Federation, Sex, FideTitle, BirthYear
+            FROM dbo.Player;
+            """;
 
         public static string GetPlayerIdBySurnameAndForenames =>
             "SELECT Id FROM dbo.Player WHERE Surname = @Surname AND Forenames = @Forenames;";
 
         public static string GetPlayersBySurname =>
-            "SELECT Id, Surname, Forenames, WasWorldChampion FROM dbo.Player WHERE LOWER(Surname) = LOWER(@Surname);";
+            """
+            SELECT Id, Surname, Forenames, WasWorldChampion,
+                   FideId, Federation, Sex, FideTitle, BirthYear
+            FROM dbo.Player
+            WHERE LOWER(Surname) = LOWER(@Surname);
+            """;
 
         public static string InsertPlayer =>
             """
@@ -26,6 +35,17 @@ namespace Repositories
             """
             UPDATE dbo.Player
             SET WasWorldChampion = @WasWorldChampion
+            WHERE Id = @Id;
+            """;
+
+        public static string UpdatePlayerFideMetadata =>
+            """
+            UPDATE dbo.Player
+            SET FideId = @FideId,
+                Federation = @Federation,
+                Sex = @Sex,
+                FideTitle = @FideTitle,
+                BirthYear = @BirthYear
             WHERE Id = @Id;
             """;
 

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -30,6 +30,9 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
     public Task UpdatePlayerWasWorldChampionAsync(int playerId, bool wasWorldChampion, CancellationToken cancellationToken = default) =>
         Throw();
 
+    public Task UpdatePlayerFideMetadataAsync(int playerId, PlayerFideMetadata metadata, CancellationToken cancellationToken = default) =>
+        Throw();
+
     public Task<int> InsertGame(Game game) => Throw<int>();
 
     public Task InsertBoardPositions(Game game, int gameId) => Throw();

--- a/test/RepositoriesTests/SqlStatementsPlayerTests.cs
+++ b/test/RepositoriesTests/SqlStatementsPlayerTests.cs
@@ -1,0 +1,35 @@
+using Repositories;
+
+namespace RepositoriesTests;
+
+public class SqlStatementsPlayerTests
+{
+    [Fact]
+    public void GetPlayers_SelectsFideMetadataColumns()
+    {
+        Assert.Contains("FideId", SqlStatements.GetPlayers, StringComparison.Ordinal);
+        Assert.Contains("Federation", SqlStatements.GetPlayers, StringComparison.Ordinal);
+        Assert.Contains("Sex", SqlStatements.GetPlayers, StringComparison.Ordinal);
+        Assert.Contains("FideTitle", SqlStatements.GetPlayers, StringComparison.Ordinal);
+        Assert.Contains("BirthYear", SqlStatements.GetPlayers, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetPlayersBySurname_SelectsFideMetadataColumns()
+    {
+        Assert.Contains("FideId", SqlStatements.GetPlayersBySurname, StringComparison.Ordinal);
+        Assert.Contains("BirthYear", SqlStatements.GetPlayersBySurname, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdatePlayerFideMetadata_UpdatesAllFideColumns()
+    {
+        var sql = SqlStatements.UpdatePlayerFideMetadata;
+        Assert.Contains("FideId = @FideId", sql, StringComparison.Ordinal);
+        Assert.Contains("Federation = @Federation", sql, StringComparison.Ordinal);
+        Assert.Contains("Sex = @Sex", sql, StringComparison.Ordinal);
+        Assert.Contains("FideTitle = @FideTitle", sql, StringComparison.Ordinal);
+        Assert.Contains("BirthYear = @BirthYear", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE Id = @Id", sql, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds migration `012` with nullable FIDE columns on `dbo.Player` (`FideId`, `Federation`, `Sex`, `FideTitle`, `BirthYear`) and filtered unique index on `FideId`.
- Extends `Player` DTO, `PlayerFideMetadata` update type, repository SQL, and `UpdatePlayerFideMetadataAsync`.
- Adds `SqlStatementsPlayerTests`; marks PLAN §15.1 complete and updates agent context.

## Test plan
- [x] `dotnet test` (520 passed)
- [ ] Run `dotnet run --project src/Migrations/Migrations.csproj` locally to apply migration `012`
- [ ] Confirm existing players have NULL FIDE columns and ETL still works
