### PR TITLE
feat: add FIDE rating list reader and player matcher (PLAN §15.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,11 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Local FIDE rating list downloads (see data/fide/README.md)
+data/fide/*
+!data/fide/README.md
+test/fide_sample/
+test/fide_sample.zip
+test/fide_combined/
+test/fide_combined.zip

--- a/data/fide/README.md
+++ b/data/fide/README.md
@@ -1,0 +1,35 @@
+# FIDE rating list files (local only)
+
+ChessAnalyser does **not** commit official FIDE rating list downloads. Obtain a list file yourself and keep it outside git (or in this folder, which is gitignored except this README).
+
+## Download
+
+1. Open [ratings.fide.com/download_lists.phtml](https://ratings.fide.com/download_lists.phtml)
+2. Download **Combined list STD, BLZ, RPD** in **TXT** format (or the Standard-only TXT if you prefer a smaller file)
+3. Save the extracted `.txt` file here, for example:
+   - `data/fide/players_list_foa.txt`
+
+## Format
+
+FIDE publishes a **fixed-width** text file. The reader (`FideRatingListReader`) parses:
+
+| Field | Notes |
+|-------|--------|
+| FIDE ID | First 15 columns |
+| Name | `Surname, Forenames` in columns 16–75 |
+| Federation | 3-letter code |
+| Sex | `M` or `F` |
+| Title | `GM`, `IM`, etc. in the title region |
+| Birth year | Last 4-digit year token on the line (before optional inactive flag) |
+
+## Usage (after PLAN §15.3 lands)
+
+```powershell
+dotnet run --project src/Analyser -- --sync-fide-metadata data/fide/players_list_foa.txt
+```
+
+Until the sync CLI exists, the reader and matcher are covered by unit tests only.
+
+## Licence
+
+Data © FIDE. Use subject to [FIDE's terms](https://ratings.fide.com/). This project stores **no** FIDE files in the repository.

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (PLAN §15.1 — player FIDE columns).
+**Last updated:** 2026-06-11 (PLAN §15.2 — FIDE list reader + matcher).
 
 ---
 
@@ -28,8 +28,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (style metrics Phases 1–8 except EcoConcentration):** through **`EcoDiversity`**; **`EcoConcentration`** unchecked (§12.6 item 16).
 - **Done (corpus benchmarks):** all benchmark-enabled style metrics through Phase 8.
 - **Done (player metadata v0):** `WasWorldChampion` on `dbo.Player`, `Ref.WorldChampion` reference table, `--sync-player-metadata` (migrations `011`/`013`).
-- **Done (player metadata v1 schema):** FIDE columns on `dbo.Player` + `UpdatePlayerFideMetadataAsync` (PLAN §15.1, branch `feat/player-fide-columns`).
-- **Next (player metadata):** PLAN §15.2 FIDE list reader + matcher.
+- **Done (player metadata v1 schema):** FIDE columns on `dbo.Player` + `UpdatePlayerFideMetadataAsync` (PLAN §15.1).
+- **Done (player metadata §15.2):** `FideRatingListReader`, `FidePlayerMatcher`, `GetPlayerCorpusActivityAsync`.
+- **Next (player metadata):** PLAN §15.3 `--sync-fide-metadata` CLI.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §13).
 
 ---
@@ -49,9 +50,9 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 ### 3.1 Recommended next step (small slice)
 
-**Do next:** [PLAN §15.2](./PLAN.md) — FIDE TXT reader + **`IFidePlayerMatcher`**.
+**Do next:** [PLAN §15.3](./PLAN.md) — `--sync-fide-metadata <path>` CLI.
 
-**Then (in order):** §15.3 `--sync-fide-metadata` CLI → §15.4 API → §15.5–15.7 filters.
+**Then (in order):** §15.4 API → §15.5–15.7 filters.
 
 **Parallel / after enrichment usable:** §12.6 **`EcoConcentration`** when maintainer wants style metrics again.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -731,16 +731,16 @@ player (e.g. Petrosian) on the same filters.
 
 **Branch:** `feat/fide-list-matcher`
 
-1. [ ] **`IFideRatingListReader`** — parse official FIDE **TXT** combined list (document column layout in code remarks; XML optional follow-up in same PR if trivial).
-2. [ ] **`FidePlayerRecord`** — `FideId`, `Name`, `Federation`, `Sex`, `Title`, `BirthYear`.
-3. [ ] **`IFidePlayerMatcher`** — match `Player` (surname, forenames) → `FidePlayerRecord?`:
+1. [x] **`IFideRatingListReader`** — parse official FIDE **TXT** combined list (document column layout in code remarks; XML optional follow-up in same PR if trivial).
+2. [x] **`FidePlayerRecord`** — `FideId`, `Name`, `Federation`, `Sex`, `Title`, `BirthYear`.
+3. [x] **`IFidePlayerMatcher`** — match `Player` (surname, forenames) → `FidePlayerRecord?`:
    - Use **`PlayerForenamesMatcher`**
    - Ambiguity resolution per DESIGN §13.5 (birth year + corpus game-year window from repository)
-4. [ ] Tests with **small inline fixture** strings (no committed 40MB file):
+4. [x] Tests with **small inline fixture** strings (no committed 40MB file):
    - Exact match `Carlsen, Magnus`
    - Abbreviated forenames
    - Ambiguous surname → no match or best-effort with birth year
-5. [ ] Document expected file location: e.g. `data/fide/README.md` — user downloads list locally; path passed to CLI.
+5. [x] Document expected file location: e.g. `data/fide/README.md` — user downloads list locally; path passed to CLI.
 
 **Acceptance:** matcher tests pass; no CLI yet.
 

--- a/src/Analyser/Program.cs
+++ b/src/Analyser/Program.cs
@@ -64,6 +64,8 @@ builder.Services.AddScoped<IBoardPositionsHelper, BoardPositionsHelper>();
 builder.Services.AddScoped<IPersistenceService, PersistenceService>();
 builder.Services.AddScoped<IPlayerResolver, PlayerResolver>();
 builder.Services.AddScoped<IWorldChampionMatcher, WorldChampionMatcher>();
+builder.Services.AddSingleton<IFideRatingListReader, FideRatingListReader>();
+builder.Services.AddScoped<IFidePlayerMatcher, FidePlayerMatcher>();
 builder.Services.AddScoped<IPlayerMetadataSyncService, PlayerMetadataSyncService>();
 builder.Services.AddScoped<IMoveInterpreter, MoveInterpreter>();
 builder.Services.AddScoped<IBoardPositionService, BoardPositionService>();

--- a/src/Interfaces/DTO/FidePlayerMatchContext.cs
+++ b/src/Interfaces/DTO/FidePlayerMatchContext.cs
@@ -1,0 +1,11 @@
+namespace Interfaces.DTO;
+
+/// <summary>Optional disambiguation hints when matching a corpus player to FIDE rows (DESIGN §13.5).</summary>
+public sealed class FidePlayerMatchContext
+{
+    public short? KnownBirthYear { get; init; }
+
+    public short? CorpusFirstGameYear { get; init; }
+
+    public short? CorpusLastGameYear { get; init; }
+}

--- a/src/Interfaces/DTO/FidePlayerMatchResult.cs
+++ b/src/Interfaces/DTO/FidePlayerMatchResult.cs
@@ -1,0 +1,16 @@
+namespace Interfaces.DTO;
+
+public enum FidePlayerMatchOutcome
+{
+    Matched,
+    Unmatched,
+    Ambiguous
+}
+
+/// <summary>Outcome of matching a corpus <see cref="Player"/> name to a FIDE list row.</summary>
+public sealed class FidePlayerMatchResult
+{
+    public FidePlayerMatchOutcome Outcome { get; init; }
+
+    public FidePlayerRecord? Record { get; init; }
+}

--- a/src/Interfaces/DTO/FidePlayerRecord.cs
+++ b/src/Interfaces/DTO/FidePlayerRecord.cs
@@ -1,0 +1,25 @@
+namespace Interfaces.DTO;
+
+/// <summary>
+/// One player row parsed from an official FIDE rating list TXT file.
+/// </summary>
+public sealed class FidePlayerRecord
+{
+    public int FideId { get; init; }
+
+    /// <summary>Full name as stored by FIDE (usually <c>Surname, Forenames</c>).</summary>
+    public string Name { get; init; } = string.Empty;
+
+    public string Surname { get; init; } = string.Empty;
+
+    public string Forenames { get; init; } = string.Empty;
+
+    public string? Federation { get; init; }
+
+    public string? Sex { get; init; }
+
+    /// <summary>Normalised title: GM, IM, WGM, FM, WFM, CM, WCM; null when untitled.</summary>
+    public string? Title { get; init; }
+
+    public short? BirthYear { get; init; }
+}

--- a/src/Interfaces/DTO/PlayerCorpusActivity.cs
+++ b/src/Interfaces/DTO/PlayerCorpusActivity.cs
@@ -1,0 +1,9 @@
+namespace Interfaces.DTO;
+
+/// <summary>First and last calendar year a player appears in the loaded game corpus (nullable years excluded).</summary>
+public sealed class PlayerCorpusActivity
+{
+    public short? FirstGameYear { get; init; }
+
+    public short? LastGameYear { get; init; }
+}

--- a/src/Repositories/ChessRepository.cs
+++ b/src/Repositories/ChessRepository.cs
@@ -45,6 +45,9 @@ namespace Repositories
         /// <summary>Returns classical world-champion name rows from <c>Ref.WorldChampion</c>.</summary>
         Task<IReadOnlyList<WorldChampionRef>> GetWorldChampions(CancellationToken cancellationToken = default);
 
+        /// <summary>First and last game year for a player in the corpus (nullable when no dated games).</summary>
+        Task<PlayerCorpusActivity?> GetPlayerCorpusActivityAsync(int playerId, CancellationToken cancellationToken = default);
+
         Task<int> InsertGame(Game game);
 
         /// <summary>
@@ -579,6 +582,19 @@ namespace Repositories
                 new CommandDefinition(SqlStatements.GetWorldChampions, cancellationToken: cancellationToken)))
                 .ToList();
             return list;
+        }
+
+        /// <inheritdoc />
+        public async Task<PlayerCorpusActivity?> GetPlayerCorpusActivityAsync(
+            int playerId,
+            CancellationToken cancellationToken = default)
+        {
+            using var connection = GetOpenConnection();
+            return await connection.QuerySingleOrDefaultAsync<PlayerCorpusActivity>(
+                new CommandDefinition(
+                    SqlStatements.GetPlayerCorpusActivity,
+                    new { PlayerId = playerId },
+                    cancellationToken: cancellationToken));
         }
 
         public async Task<List<string>> GetProcessedGameIds()

--- a/src/Repositories/SqlStatements.cs
+++ b/src/Repositories/SqlStatements.cs
@@ -56,6 +56,15 @@ namespace Repositories
             ORDER BY ChampionOrder, Surname, Forenames;
             """;
 
+        public static string GetPlayerCorpusActivity =>
+            """
+            SELECT MIN(g.GameYear) AS FirstGameYear,
+                   MAX(g.GameYear) AS LastGameYear
+            FROM dbo.Game g
+            WHERE g.GameYear IS NOT NULL
+              AND (g.WhitePlayerId = @PlayerId OR g.BlackPlayerId = @PlayerId);
+            """;
+
         public static string InsertGame =>
         """
         IF (NOT EXISTS (SELECT TOP 1 Id FROM dbo.Game WHERE GameId = @GameId))

--- a/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
+++ b/src/Services/Analytics/MaterializationWriteOnlyNoOpRepository.cs
@@ -36,6 +36,9 @@ public sealed class MaterializationWriteOnlyNoOpRepository : IChessRepository
     public Task<IReadOnlyList<WorldChampionRef>> GetWorldChampions(CancellationToken cancellationToken = default) =>
         Throw<IReadOnlyList<WorldChampionRef>>();
 
+    public Task<PlayerCorpusActivity?> GetPlayerCorpusActivityAsync(int playerId, CancellationToken cancellationToken = default) =>
+        Throw<PlayerCorpusActivity?>();
+
     public Task<int> InsertGame(Game game) => Throw<int>();
 
     public Task InsertBoardPositions(Game game, int gameId) => Throw();

--- a/src/Services/PlayerMetadata/FidePlayerMatcher.cs
+++ b/src/Services/PlayerMetadata/FidePlayerMatcher.cs
@@ -1,0 +1,94 @@
+using Interfaces.DTO;
+using Services.Helpers;
+
+namespace Services.PlayerMetadata;
+
+/// <inheritdoc />
+public sealed class FidePlayerMatcher : IFidePlayerMatcher
+{
+    private IReadOnlyList<FidePlayerRecord> _records = Array.Empty<FidePlayerRecord>();
+    private Dictionary<string, List<FidePlayerRecord>> _bySurname = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public void SetRecords(IReadOnlyList<FidePlayerRecord> records)
+    {
+        _records = records ?? throw new ArgumentNullException(nameof(records));
+        _bySurname = records
+            .GroupBy(r => r.Surname.Trim(), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public FidePlayerMatchResult Match(string surname, string? forenames, FidePlayerMatchContext? context = null)
+    {
+        if (string.IsNullOrWhiteSpace(surname))
+            return Unmatched();
+
+        if (!_bySurname.TryGetValue(surname.Trim(), out var candidates))
+            return Unmatched();
+
+        var forenamesNorm = (forenames ?? string.Empty).Trim();
+        var matches = candidates
+            .Where(c => PlayerForenamesMatcher.ForenamesMatch(c.Forenames, forenamesNorm))
+            .ToList();
+
+        if (matches.Count == 0)
+            return Unmatched();
+
+        if (matches.Count == 1)
+            return Matched(matches[0]);
+
+        return ResolveAmbiguous(matches, context);
+    }
+
+    private static FidePlayerMatchResult ResolveAmbiguous(
+        IReadOnlyList<FidePlayerRecord> matches,
+        FidePlayerMatchContext? context)
+    {
+        var scored = matches
+            .Select(m => (Record: m, Score: ScoreCandidate(m, context)))
+            .OrderByDescending(x => x.Score)
+            .ThenBy(x => x.Record.FideId)
+            .ToList();
+
+        if (scored[0].Score >= 100)
+            return Matched(scored[0].Record);
+
+        if (scored.Count >= 2 && scored[0].Score >= 30 && scored[0].Score - scored[1].Score >= 20)
+            return Matched(scored[0].Record);
+
+        return new FidePlayerMatchResult { Outcome = FidePlayerMatchOutcome.Ambiguous };
+    }
+
+    internal static int ScoreCandidate(FidePlayerRecord candidate, FidePlayerMatchContext? context)
+    {
+        if (context is null)
+            return 0;
+
+        var score = 0;
+
+        if (context.KnownBirthYear is short knownBirth && candidate.BirthYear == knownBirth)
+            score += 100;
+        else if (context.KnownBirthYear is short kb && candidate.BirthYear is short cb &&
+                 Math.Abs(kb - cb) <= 1)
+            score += 50;
+
+        if (context.CorpusFirstGameYear is short first &&
+            context.CorpusLastGameYear is short last &&
+            candidate.BirthYear is short birth)
+        {
+            if (first >= birth + 8 && last <= birth + 100)
+                score += 30;
+            else if (first >= birth + 5 && last <= birth + 110)
+                score += 10;
+        }
+
+        return score;
+    }
+
+    private static FidePlayerMatchResult Matched(FidePlayerRecord record) =>
+        new() { Outcome = FidePlayerMatchOutcome.Matched, Record = record };
+
+    private static FidePlayerMatchResult Unmatched() =>
+        new() { Outcome = FidePlayerMatchOutcome.Unmatched };
+}

--- a/src/Services/PlayerMetadata/FideRatingListFieldLayout.cs
+++ b/src/Services/PlayerMetadata/FideRatingListFieldLayout.cs
@@ -1,0 +1,26 @@
+namespace Services.PlayerMetadata;
+
+/// <summary>
+/// Fixed-width column slices for FIDE rating list TXT files (standard and combined STD/RPD/BLZ).
+/// Verified against <c>standard_rating_list.txt</c> and <c>players_list_foa.txt</c> from ratings.fide.com.
+/// </summary>
+internal static class FideRatingListFieldLayout
+{
+    internal const int MinLineLength = 130;
+
+    internal const int IdStart = 0;
+    internal const int IdLength = 15;
+
+    internal const int NameStart = 15;
+    internal const int NameLength = 60;
+
+    internal const int FederationStart = 76;
+    internal const int FederationLength = 3;
+
+    internal const int SexStart = 80;
+    internal const int SexLength = 1;
+
+    /// <summary>Tit + WTit region (may contain spaces; normalised by <see cref="FideTitleNormalizer"/>).</summary>
+    internal const int TitleRegionStart = 81;
+    internal const int TitleRegionLength = 14;
+}

--- a/src/Services/PlayerMetadata/FideRatingListReader.cs
+++ b/src/Services/PlayerMetadata/FideRatingListReader.cs
@@ -1,0 +1,115 @@
+using System.Globalization;
+using Interfaces.DTO;
+using Services.Helpers;
+
+namespace Services.PlayerMetadata;
+
+/// <inheritdoc />
+public sealed class FideRatingListReader : IFideRatingListReader
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FidePlayerRecord>> ReadAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException("FIDE rating list file was not found.", filePath);
+
+        var records = new List<FidePlayerRecord>();
+        await foreach (var line in ReadLinesAsync(filePath, cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (TryParseLine(line, out var record))
+                records.Add(record);
+        }
+
+        return records;
+    }
+
+    internal static bool TryParseLine(string line, out FidePlayerRecord record)
+    {
+        record = null!;
+        if (string.IsNullOrWhiteSpace(line) || line.StartsWith("ID Number", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (line.Length < FideRatingListFieldLayout.MinLineLength)
+            return false;
+
+        var idText = Slice(line, FideRatingListFieldLayout.IdStart, FideRatingListFieldLayout.IdLength);
+        if (!int.TryParse(idText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var fideId) || fideId <= 0)
+            return false;
+
+        var name = Slice(line, FideRatingListFieldLayout.NameStart, FideRatingListFieldLayout.NameLength);
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        PlayerNameParser.Parse(name, out var surname, out var forenames);
+
+        var federation = NullIfEmpty(Slice(line, FideRatingListFieldLayout.FederationStart, FideRatingListFieldLayout.FederationLength));
+        var sex = NullIfEmpty(Slice(line, FideRatingListFieldLayout.SexStart, FideRatingListFieldLayout.SexLength));
+        var titleRegion = Slice(line, FideRatingListFieldLayout.TitleRegionStart, FideRatingListFieldLayout.TitleRegionLength);
+        var title = FideTitleNormalizer.Normalize(titleRegion);
+        var birthYear = TryParseBirthYear(line);
+
+        record = new FidePlayerRecord
+        {
+            FideId = fideId,
+            Name = name,
+            Surname = surname,
+            Forenames = forenames,
+            Federation = federation,
+            Sex = sex,
+            Title = title,
+            BirthYear = birthYear
+        };
+        return true;
+    }
+
+    private static short? TryParseBirthYear(string line)
+    {
+        var parts = line.TrimEnd().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = parts.Length - 1; i >= 0; i--)
+        {
+            var part = parts[i];
+            if (part is "i" or "wi" or "w")
+                continue;
+
+            if (part.Length == 4 &&
+                short.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out var year) &&
+                year is >= 1800 and <= 2100)
+                return year;
+
+            break;
+        }
+
+        return null;
+    }
+
+    private static string Slice(string line, int start, int length)
+    {
+        if (start >= line.Length)
+            return string.Empty;
+
+        var take = Math.Min(length, line.Length - start);
+        return line.Substring(start, take).Trim();
+    }
+
+    private static string? NullIfEmpty(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static async IAsyncEnumerable<string> ReadLinesAsync(
+        string filePath,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(filePath);
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            if (line is null)
+                yield break;
+            yield return line;
+        }
+    }
+}

--- a/src/Services/PlayerMetadata/FideTitleNormalizer.cs
+++ b/src/Services/PlayerMetadata/FideTitleNormalizer.cs
@@ -1,0 +1,43 @@
+namespace Services.PlayerMetadata;
+
+/// <summary>Maps FIDE title tokens from rating-list TXT to normalised codes stored on <see cref="Interfaces.DTO.Player"/>.</summary>
+internal static class FideTitleNormalizer
+{
+    private static readonly Dictionary<string, string> SingleLetterCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["g"] = "GM",
+        ["m"] = "IM",
+        ["f"] = "FM",
+        ["c"] = "CM",
+        ["wg"] = "WGM",
+        ["wm"] = "WIM",
+        ["wf"] = "WFM",
+        ["wc"] = "WCM",
+    };
+
+    private static readonly string[] MultiCharTitles = ["WGM", "WIM", "WFM", "WCM", "GM", "IM", "FM", "CM"];
+
+    internal static string? Normalize(string? titleRegion)
+    {
+        if (string.IsNullOrWhiteSpace(titleRegion))
+            return null;
+
+        var compact = string.Concat(titleRegion.Where(c => !char.IsWhiteSpace(c)));
+        if (compact.Length == 0)
+            return null;
+
+        foreach (var title in MultiCharTitles)
+        {
+            if (compact.Contains(title, StringComparison.OrdinalIgnoreCase))
+                return title;
+        }
+
+        foreach (var pair in SingleLetterCodes)
+        {
+            if (compact.Equals(pair.Key, StringComparison.OrdinalIgnoreCase))
+                return pair.Value;
+        }
+
+        return null;
+    }
+}

--- a/src/Services/PlayerMetadata/IFidePlayerMatcher.cs
+++ b/src/Services/PlayerMetadata/IFidePlayerMatcher.cs
@@ -1,0 +1,15 @@
+using Interfaces.DTO;
+
+namespace Services.PlayerMetadata;
+
+/// <summary>Matches corpus player names to rows from a FIDE rating list.</summary>
+public interface IFidePlayerMatcher
+{
+    /// <summary>Indexes FIDE rows for matching. Call once per list load.</summary>
+    void SetRecords(IReadOnlyList<FidePlayerRecord> records);
+
+    /// <summary>
+    /// Finds a FIDE row for the given surname and forenames using <see cref="Services.Helpers.PlayerForenamesMatcher"/>.
+    /// </summary>
+    FidePlayerMatchResult Match(string surname, string? forenames, FidePlayerMatchContext? context = null);
+}

--- a/src/Services/PlayerMetadata/IFideRatingListReader.cs
+++ b/src/Services/PlayerMetadata/IFideRatingListReader.cs
@@ -1,0 +1,10 @@
+using Interfaces.DTO;
+
+namespace Services.PlayerMetadata;
+
+/// <summary>Reads official FIDE rating list TXT files (fixed-width format).</summary>
+public interface IFideRatingListReader
+{
+    /// <summary>Parses all player rows from a FIDE TXT list file.</summary>
+    Task<IReadOnlyList<FidePlayerRecord>> ReadAsync(string filePath, CancellationToken cancellationToken = default);
+}

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -13,7 +13,7 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <InternalsVisibleTo Include="ServicesTests" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Interfaces\Interfaces.csproj" />

--- a/test/RepositoriesTests/SqlStatementsPlayerTests.cs
+++ b/test/RepositoriesTests/SqlStatementsPlayerTests.cs
@@ -39,4 +39,11 @@ public class SqlStatementsPlayerTests
         Assert.Contains("Ref.WorldChampion", SqlStatements.GetWorldChampions, StringComparison.Ordinal);
         Assert.Contains("ChampionOrder", SqlStatements.GetWorldChampions, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void GetPlayerCorpusActivity_SelectsMinMaxGameYear()
+    {
+        Assert.Contains("MIN(g.GameYear)", SqlStatements.GetPlayerCorpusActivity, StringComparison.Ordinal);
+        Assert.Contains("MAX(g.GameYear)", SqlStatements.GetPlayerCorpusActivity, StringComparison.Ordinal);
+    }
 }

--- a/test/ServicesTests/PlayerMetadata/FideRatingListReaderTests.cs
+++ b/test/ServicesTests/PlayerMetadata/FideRatingListReaderTests.cs
@@ -1,0 +1,141 @@
+using Interfaces.DTO;
+using Services.PlayerMetadata;
+
+namespace ServicesTests.PlayerMetadata;
+
+public class FideRatingListReaderTests
+{
+    private static string FixturePath =>
+        Path.Combine(AppContext.BaseDirectory, "PlayerMetadata", "Fixtures", "fide_sample.txt");
+
+    [Fact]
+    public async Task ReadAsync_ParsesOfficialFixedWidthRows()
+    {
+        var sut = new FideRatingListReader();
+        var records = await sut.ReadAsync(FixturePath);
+
+        Assert.Equal(4, records.Count);
+
+        var carlsen = records.Single(r => r.FideId == 1_503_014);
+        Assert.Equal("Carlsen, Magnus", carlsen.Name);
+        Assert.Equal("Carlsen", carlsen.Surname);
+        Assert.Equal("Magnus", carlsen.Forenames);
+        Assert.Equal("NOR", carlsen.Federation);
+        Assert.Equal("M", carlsen.Sex);
+        Assert.Equal("GM", carlsen.Title);
+        Assert.Equal((short)1990, carlsen.BirthYear);
+
+        var flagged = records.Single(r => r.FideId == 25_121_731);
+        Assert.Equal((short)1987, flagged.BirthYear);
+    }
+
+    [Fact]
+    public void TryParseLine_RejectsHeaderAndShortLines()
+    {
+        Assert.False(FideRatingListReader.TryParseLine("ID Number      Name", out _));
+        Assert.False(FideRatingListReader.TryParseLine("too short", out _));
+    }
+}
+
+public class FidePlayerMatcherTests
+{
+    [Fact]
+    public void Match_ExactCarlsen_ReturnsMatched()
+    {
+        var records = new List<FidePlayerRecord>
+        {
+            new()
+            {
+                FideId = 1_503_014,
+                Name = "Carlsen, Magnus",
+                Surname = "Carlsen",
+                Forenames = "Magnus",
+                Federation = "NOR",
+                Sex = "M",
+                Title = "GM",
+                BirthYear = 1990
+            }
+        };
+
+        var sut = new FidePlayerMatcher();
+        sut.SetRecords(records);
+
+        var result = sut.Match("Carlsen", "Magnus");
+
+        Assert.Equal(FidePlayerMatchOutcome.Matched, result.Outcome);
+        Assert.Equal(1_503_014, result.Record!.FideId);
+    }
+
+    [Fact]
+    public void Match_AbbreviatedForenames_ReturnsMatched()
+    {
+        var records = new List<FidePlayerRecord>
+        {
+            new()
+            {
+                FideId = 1_503_014,
+                Surname = "Carlsen",
+                Forenames = "Magnus",
+                Name = "Carlsen, Magnus",
+                BirthYear = 1990
+            }
+        };
+
+        var sut = new FidePlayerMatcher();
+        sut.SetRecords(records);
+
+        var result = sut.Match("Carlsen", "M");
+
+        Assert.Equal(FidePlayerMatchOutcome.Matched, result.Outcome);
+    }
+
+    [Fact]
+    public void Match_AmbiguousSurnameForenames_UsesBirthYearHint()
+    {
+        var records = new List<FidePlayerRecord>
+        {
+            new() { FideId = 1, Surname = "Carlsen", Forenames = "Alexander", Name = "Carlsen, Alexander", BirthYear = 1990 },
+            new() { FideId = 2, Surname = "Carlsen", Forenames = "Alexander A", Name = "Carlsen, Alexander A", BirthYear = 1995 }
+        };
+
+        var sut = new FidePlayerMatcher();
+        sut.SetRecords(records);
+
+        var ambiguous = sut.Match("Carlsen", "Alexander");
+        Assert.Equal(FidePlayerMatchOutcome.Ambiguous, ambiguous.Outcome);
+
+        var withBirthYear = sut.Match("Carlsen", "Alexander", new FidePlayerMatchContext { KnownBirthYear = 1995 });
+        Assert.Equal(FidePlayerMatchOutcome.Matched, withBirthYear.Outcome);
+        Assert.Equal(2, withBirthYear.Record!.FideId);
+    }
+
+    [Fact]
+    public void Match_UnknownPlayer_ReturnsUnmatched()
+    {
+        var sut = new FidePlayerMatcher();
+        sut.SetRecords([]);
+
+        var result = sut.Match("Morphy", "Paul");
+
+        Assert.Equal(FidePlayerMatchOutcome.Unmatched, result.Outcome);
+        Assert.Null(result.Record);
+    }
+
+    [Fact]
+    public void ScoreCandidate_CorpusYearsBoostsPlausibleCandidate()
+    {
+        var candidate = new FidePlayerRecord
+        {
+            FideId = 1,
+            Surname = "Carlsen",
+            Forenames = "Alexander",
+            BirthYear = 1995
+        };
+
+        var score = FidePlayerMatcher.ScoreCandidate(
+            candidate,
+            new FidePlayerMatchContext { CorpusFirstGameYear = 2010, CorpusLastGameYear = 2020 });
+
+        Assert.True(score >= 30);
+    }
+}

--- a/test/ServicesTests/PlayerMetadata/Fixtures/fide_sample.txt
+++ b/test/ServicesTests/PlayerMetadata/Fixtures/fide_sample.txt
@@ -1,0 +1,5 @@
+ID Number      Name                                                         Fed Sex Tit  WTit OTit           FOA SRtng SGm SK RRtng RGm Rk BRtng BGm BK B-day Flag
+1503014        Carlsen, Magnus                                              NOR M   GM                           2841  7   10 2832  0   10 2869  0   10 1990      
+1487710        Carlsen, Alexander Joe Stucke                                DEN M                                1470  3   40 1995      
+2016192        Nakamura, Hikaru                                             USA M   GM                           2750  0   10 2837  0   10 2850  0   10 1987      
+25121731       A C J John                                                   IND M                                1438  0   40 1987  i   

--- a/test/ServicesTests/ServicesTests.csproj
+++ b/test/ServicesTests/ServicesTests.csproj
@@ -49,6 +49,9 @@
     <None Update="TestData\Integration\etl_progress_sample.pgn">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="PlayerMetadata\Fixtures\fide_sample.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Adds `FideRatingListReader` for official FIDE fixed-width TXT lists (standard and combined).
- Adds `FidePlayerMatcher` with `PlayerForenamesMatcher` and birth-year / corpus-year disambiguation.
- Adds `GetPlayerCorpusActivityAsync` on the repository for sync use in §15.3.
- Includes test fixture, unit tests, and `data/fide/README.md` download instructions.

## Test plan
- [x] `dotnet test` (529 passed)
- [ ] Download a FIDE combined TXT to `data/fide/` locally (not committed)
- [ ] §15.3 follow-up: `--sync-fide-metadata` CLI
