### PR TITLE
docs: align player metadata docs with automatic enrichment

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Let a **new** chat or agent continue without re-reading full history. Update this file when you finish a meaningful slice of work.
 
-**Last updated:** 2026-06-11 (PLAN §15.3 — `Ref.FidePlayer` catalog + auto-enrichment).
+**Last updated:** 2026-06-11 (PLAN §15.3 merged — PR #75: `Ref.FidePlayer` + automatic enrichment).
 
 ---
 
@@ -27,10 +27,10 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 - **Done (analytics groundwork):** **PLAN §11** (items 1–13) and **§12** (metrics HTTP API + local **`wwwroot`** UI).
 - **Done (style metrics Phases 1–8 except EcoConcentration):** through **`EcoDiversity`**; **`EcoConcentration`** unchecked (§12.6 item 16).
 - **Done (corpus benchmarks):** all benchmark-enabled style metrics through Phase 8.
-- **Done (player metadata v0):** `WasWorldChampion` on `dbo.Player`, `Ref.WorldChampion` reference table, `--sync-player-metadata` (migrations `011`/`013`).
+- **Done (player metadata v0):** `WasWorldChampion` on `dbo.Player`, `Ref.WorldChampion` reference table (migrations `011`/`013`); backfill via `IPlayerFideMetadataEnricher.EnrichAllAsync()` (Migrations host + end of ETL).
 - **Done (player metadata v1 schema):** FIDE columns on `dbo.Player` + `UpdatePlayerFideMetadataAsync` (PLAN §15.1).
 - **Done (player metadata §15.2):** `FideRatingListReader`, `FidePlayerMatcher`, `GetPlayerCorpusActivityAsync`.
-- **Done (player metadata §15.3):** `Ref.FidePlayer`, migration `015` auto-seeds from `data/fide/players_list_foa.txt`, player backfill in Migrations host, ETL auto-enrich.
+- **Done (player metadata §15.3, PR #75):** `Ref.FidePlayer` catalog; migration `015` + Migrations host seed from `data/fide/players_list_foa.txt`; `IPlayerFideMetadataEnricher` (idempotent backfill + per-game ETL enrichment with **GameYear** verification); homonym rejection when birth year > corpus game years.
 - **Next (player metadata):** PLAN §15.4 API — expose metadata on player picker.
 - **HTTP auth for metrics is deferred** while the app stays **local-only / undeployed** (see PLAN §12.1 / §13).
 
@@ -74,7 +74,7 @@ All **Design / Plan / Implement** specs for **board-position analytics** live in
 
 - **`dbo.GameMove`** + **`dbo.GamePositionSummary`** — derived on ETL/backfill; required for style metrics.
 - **Corpus benchmarks:** opt-in `includeCorpusBenchmark` + `benchmarkMinGames` (default 30); shared `ICorpusBenchmarkCalculator`.
-- **Player metadata today:** `WasWorldChampion` only; FIDE columns and filters per §13/§15.
+- **Player metadata today:** `WasWorldChampion` (on insert + enricher backfill); FIDE columns (`FideId`, `Federation`, `Sex`, `FideTitle`, `BirthYear`) populated automatically when `Ref.FidePlayer` is seeded — migrations host backfill + ETL per-game/`EnrichAllAsync`. No manual Analyser CLI. Metadata **filters** on analytics/games still pending (§15.5–15.7).
 - **Conventions:** [PLAN.md §7](./PLAN.md), [DESIGN.md §8](./DESIGN.md).
 
 ---

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -296,7 +296,7 @@ See also [STYLE_METRICS.md §8](./STYLE_METRICS.md).
 
 **Context (2026):** Many PGN collections carry **game** headers (event, date, ECO, result) and **player names** only. `[WhiteElo]`, `[WhiteTitle]`, and similar tags are often absent. Player attributes for filtering and cohort analysis must therefore come from **external reference data**, not from the PGN alone.
 
-**Relationship to existing work:** `WasWorldChampion` on `dbo.Player` (migration `011`) is set from **`Ref.WorldChampion`** (migration `013`) via `IWorldChampionMatcher` on insert and `--sync-player-metadata` for backfill. §13 generalises enrichment (FIDE bulk sync) and defines **filter semantics** for analytics.
+**Relationship to existing work:** `WasWorldChampion` on `dbo.Player` (migration `011`) is set from **`Ref.WorldChampion`** (migration `013`) via `IWorldChampionMatcher` on player insert; **`IPlayerFideMetadataEnricher`** re-applies world-champion and FIDE metadata idempotently (Migrations host after seed, end of ETL, and per game with **GameYear**). §13 defines **filter semantics** for analytics (filters not yet wired — PLAN §15.5+).
 
 ### 13.1 Goals
 
@@ -314,7 +314,7 @@ See also [STYLE_METRICS.md §8](./STYLE_METRICS.md).
 | Rating **at game time** | Needs historical monthly rating series or `WhiteElo`/`BlackElo` on `Game`; not a static `Player` column. |
 | “World champion **when this game was played**” | Needs **reign periods**, not `WasWorldChampion` alone. |
 | Wikidata bulk import | Optional follow-up; FIDE + curated catalogs cover most filter needs first. |
-| Automatic enrichment during live PGN parse | FIDE metadata only when **`Ref.FidePlayer`** is loaded; world-champion flag on insert always. |
+| Network calls during ETL / migrations | Bulk FIDE file is local-only; optional Lichess fallback deferred. Parse and migrations succeed when catalog is empty (FIDE columns stay NULL). |
 | EAV / JSON metadata blob as primary store | v1 uses **indexed nullable columns** on `Player`; revisit if many new attribute types appear. |
 
 ### 13.3 Player schema (v1 enrichment columns)
@@ -359,7 +359,7 @@ PGN names are parsed to `(Surname, Forenames)` via `PlayerNameParser`. FIDE list
 
 1. **Normalise** trim and case for comparison; reuse **`PlayerForenamesMatcher`** for forename abbreviations (`A` vs `Alexander`).
 2. **Exact match** on normalised surname + forenames → assign `FideId` and fields.
-3. **Ambiguous** (multiple FIDE rows same surname, matcher ties) → score candidates with **birth year** (if set on either side) and **corpus activity** (`MIN`/`MAX` `GameYear` for that `PlayerId`); pick highest confidence only if above threshold; else leave `FideId` NULL and log/count as unmatched.
+3. **Ambiguous** (multiple FIDE rows same surname, matcher ties) → score candidates with **birth year** (if set on either side) and **corpus activity** (`MIN`/`MAX` `GameYear` for that `PlayerId`); **reject** candidates whose birth year is **after any known corpus game year** (homonym guard); pick highest confidence only if above threshold; else leave `FideId` NULL and log/count as unmatched.
 4. **No auto-merge** of distinct `Player` rows — homonyms stay separate unless manually corrected later.
 5. **Re-sync idempotent:** running sync again updates FIDE-sourced columns; never clears `WasWorldChampion` from catalog logic.
 
@@ -410,22 +410,24 @@ Express as a small list of conditions (extensible):
 ### 13.7 Architecture sketch
 
 ```
-PGN ingest → Player (name) + Game (dims)
+data/fide/players_list_foa.txt  (local, gitignored)
        ↓
---sync-player-metadata  → optional re-backfill WasWorldChampion + FIDE columns from Ref.*
-ETL new player insert   → auto-enrich when Ref.FidePlayer is loaded
-Migration 015 host      → seeds Ref.FidePlayer from data/fide/players_list_foa.txt when empty
+Migration 015 host  →  seed Ref.FidePlayer when empty  →  EnrichAllAsync (backfill dbo.Player)
        ↓
-AnalyticsQuery + PlayerMetadataFilter
+PGN ingest (ETL)  →  Player insert (WasWorldChampion on insert)
+                  →  per game: TryEnrichPlayerAsync(white/black, GameYear)
+                  →  end of load: EnrichAllAsync (idempotent)
+       ↓
+AnalyticsQuery + PlayerMetadataFilter  (PLAN §15.5+)
        ↓
 PlayerMetadataSql.Apply(filter, wp, bp, subjectContext)  →  AND … on FilteredGames
        ↓
 ICorpusBenchmarkCalculator (optional CorpusPool predicate)
 ```
 
-- **Services:** `IFideRatingListReader`, `IFidePlayerMatcher`, extend `IPlayerMetadataSyncService` (or sibling `IFideMetadataSyncService`).
-- **No network in default sync path** — user passes `--fide-list path/to/file.txt`.
-- **UI:** one “Player metadata” subsection under metrics and games (checkboxes / dropdowns mapping to predicates + role).
+- **Services:** `IFideRatingListReader`, `IFidePlayerMatcher`, `IPlayerFideMetadataEnricher`, `FidePlayerMatchContextBuilder`; `IPlayerMetadataSyncService` retained for legacy call sites.
+- **No network in default path** — configure `FideCatalog:ListPath` in `src/Migrations/appsettings.json`; see `data/fide/README.md`.
+- **UI:** one “Player metadata” subsection under metrics and games (checkboxes / dropdowns mapping to predicates + role) — PLAN §15.4+.
 
 ### 13.8 Interpretation
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -697,7 +697,7 @@ player (e.g. Petrosian) on the same filters.
 
 **Goal:** Enrich `dbo.Player` from **external reference data** (primarily FIDE bulk files) and support **optional metadata filters** on analytics and game browsing per [DESIGN.md §13](./DESIGN.md).
 
-**Decision (2026):** PGN files being loaded are **metadata-thin** (game headers + names). Player title, federation, sex, and birth year will **not** come from PGN tags in v1. Enrichment is a **post-load / post-ingest CLI step**, not inline with parse.
+**Decision (2026):** PGN files being loaded are **metadata-thin** (game headers + names). Player title, federation, sex, and birth year will **not** come from PGN tags in v1. Enrichment is **automatic and offline**: migrations seed `Ref.FidePlayer` and backfill existing players; ETL enriches each game's white/black using that game's **GameYear**, then runs a full idempotent pass — no separate Analyser CLI.
 
 **Non-goals for Stage 5 v1:** historical rating at game time, reign-period champion filters, Wikidata bulk import, Lichess fallback (optional later slice).
 
@@ -740,7 +740,7 @@ player (e.g. Petrosian) on the same filters.
    - Exact match `Carlsen, Magnus`
    - Abbreviated forenames
    - Ambiguous surname → no match or best-effort with birth year
-5. [x] Document expected file location: e.g. `data/fide/README.md` — user downloads list locally; path passed to CLI.
+5. [x] Document expected file location: `data/fide/README.md` — user downloads list locally; Migrations host loads it when `Ref.FidePlayer` is empty.
 
 **Acceptance:** matcher tests pass; no CLI yet.
 
@@ -752,11 +752,12 @@ player (e.g. Petrosian) on the same filters.
 
 1. [x] Migration **`014_CreateRefFidePlayer.sql`** — `Ref.FidePlayer` catalog table.
 2. [x] Migration **`015_SeedRefFidePlayer.sql`** + Migrations host — load `data/fide/players_list_foa.txt` into Ref when empty; backfill `dbo.Player`.
-3. [x] **`IPlayerFideMetadataEnricher`** — backfill all players + enrich on ETL insert (`PlayerResolver`).
-4. [x] No manual Analyser CLI import — seed runs as part of `dotnet run --project src/Migrations`.
-5. [x] Service tests.
+3. [x] **`IPlayerFideMetadataEnricher`** — `EnrichAllAsync()` backfill + `TryEnrichPlayerAsync(playerId, gameYear)` on each persisted game (`EtlService`); `PlayerResolver` sets `WasWorldChampion` on insert only.
+4. [x] **Game-year verification** in `FidePlayerMatcher` — reject candidates whose birth year is after any corpus game year; clear incompatible stored FIDE metadata on re-enrichment.
+5. [x] No manual Analyser CLI import — seed runs as part of `dotnet run --project src/Migrations`.
+6. [x] Service tests (including homonym / Botvinnik fixture).
 
-**Acceptance:** migrations populate Ref + players when FIDE file is present; new ETL players auto-enriched; idempotent re-run.
+**Acceptance:** migrations populate Ref + players when FIDE file is present; new ETL players auto-enriched per game year; idempotent re-run.
 
 **Note:** ~1.8M-row catalog is streamed by the Migrations host (not a multi-GB SQL INSERT script in git).
 


### PR DESCRIPTION
## Summary
- Update AGENT_CONTEXT, DESIGN, and PLAN to reflect PR #75 automatic enrichment (no manual CLI)
- Document IPlayerFideMetadataEnricher flow: migrations seed/backfill, ETL per-game GameYear enrichment, end-of-load EnrichAllAsync
- Add game-year homonym guard to DESIGN §13.5; fix §15.3 checklist (EtlService vs PlayerResolver)

## Test plan
- [x] Documentation-only change; no code or tests affected

Made with [Cursor](https://cursor.com)